### PR TITLE
Feature new package eictoymodel

### DIFF
--- a/packages/eictoymodel/package.py
+++ b/packages/eictoymodel/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class EictoymodelGit(CMakePackage):
+    """EicToyModel (ETM) is a C++ ROOT-based software suite
+    for EIC Central Detector configuration purposes."""
+
+    homepage = "http://github.com/eic/EicToyModel"
+    url      = "http://github.com/eic/EicToyModel.git"
+    git      = "http://github.com/eic/EicToyModel.git"
+
+    version('master', branch='master')
+
+    depends_on('root')
+    depends_on('vgm')
+    depends_on('oce')
+
+    def cmake_args(self):
+        args = []
+        # C++ Standard
+        args.append('-DCMAKE_CXX_STANDARD=%s'
+                % self.spec['root'].variants['cxxstd'].value)
+        args.append('-DOPENCASCADE=%s'
+                % self.spec['oce'].prefix)
+        return args
+

--- a/packages/eictoymodel/package.py
+++ b/packages/eictoymodel/package.py
@@ -26,6 +26,6 @@ class Eictoymodel(CMakePackage):
         args.append('-DCMAKE_CXX_STANDARD=%s'
                 % self.spec['root'].variants['cxxstd'].value)
         args.append('-DOPENCASCADE=%s'
-                % self.spec['oce'].prefix)
+                % self.spec['opencascade'].prefix)
         return args
 

--- a/packages/eictoymodel/package.py
+++ b/packages/eictoymodel/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class EictoymodelGit(CMakePackage):
+class Eictoymodel(CMakePackage):
     """EicToyModel (ETM) is a C++ ROOT-based software suite
     for EIC Central Detector configuration purposes."""
 
@@ -16,9 +16,9 @@ class EictoymodelGit(CMakePackage):
 
     version('master', branch='master')
 
+    depends_on('opencascade')
     depends_on('root')
     depends_on('vgm')
-    depends_on('oce')
 
     def cmake_args(self):
         args = []

--- a/packages/escalate/package.py
+++ b/packages/escalate/package.py
@@ -43,6 +43,7 @@ class Escalate(BundlePackage):
     depends_on('jana2 +root +zmq', when='@develop')
     # EicRoot
     depends_on('eicroot@master')
+    depends_on('eictoymodel@master')
 
     version('1.0.1')
     # gcc 9.2
@@ -80,3 +81,4 @@ class Escalate(BundlePackage):
     depends_on('jana2@2.0.2 +root +zmq', when='@1.0.1')
     # EicRoot
     depends_on('eicroot@master')
+    depends_on('eictoymodel@master')


### PR DESCRIPTION
After https://github.com/eic/EicToyModel/pull/1 has been merged, this should build fine and can be integrated in the escalate dummy package.