### PR TITLE
New version: eic-smear-1.1.0-rc1

### DIFF
--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -11,7 +11,7 @@ class EicSmear(CMakePackage):
     developed by the BNL EIC task force."""
 
     homepage = "https://wiki.bnl.gov/eic/index.php/Monte_Carlo_and_Smearing"
-    url      = "https://github.com/eic/eic-smear"
+    url      = "https://github.com/eic/eic-smear/archive/1.0.4.tar.gz"
     git      = "https://github.com/eic/eic-smear.git"
 
     maintainers = ['wdconinc']
@@ -19,11 +19,13 @@ class EicSmear(CMakePackage):
     variant("pythia6", default=False, description="Include Pythia6 support")
 
     version('master', branch='master')
-    version('1.1.0-rc1',  branch='1.1.0-rc1')
-    version('1.0.4',  branch='1.0.4')
-    version('1.0.3',  branch='1.0.3')
-    version('1.0.2',  branch='1.0.2')
-    version('1.0.1',  branch='1.0.1')
+    version('1.1.0-rc1',  sha256='e3da232320522fb078f8795ee31f06032bae454ccc7c9368e393c94ab4b88db0')
+    version('1.0.4-fix1', sha256='ae312f4440b7ec5eeda75631bea209d733186199eaa3cd76c757ba1337679392')
+    version('1.0.4',      sha256='7d12a1d8b1c490502cd73737e1ce264880b04e74c16ee3b27cabad371c5b9e73')
+    version('1.0.3',      sha256='74b0e7a690b8fe81eb2e2ea78f96cb75aadca1c8b08450e89a7ebf8963a4d44c')
+    version('1.0.2',      sha256='5f33b8ba75120918023be458d9fb0f138e1d41dd37ca7107d3aa6e0ab51b691c')
+    version('1.0.1',      sha256='60b4222e41c6cf5c9cbb30c85e388ce06f1e585c5a970d34ef4d1394c058ccdc')
+    version('1.0.0',      sha256='be994c94b5b665f3802723a51e5983a0d9221ca3b13138146d68ba48eb0b2d93')
 
     depends_on('root')
     depends_on('cmake', type='build')

--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -11,14 +11,15 @@ class EicSmear(CMakePackage):
     developed by the BNL EIC task force."""
 
     homepage = "https://wiki.bnl.gov/eic/index.php/Monte_Carlo_and_Smearing"
-    url      = "https://gitlab.com/eic/eic-smear"
-    git      = "https://gitlab.com/eic/eic-smear.git"
+    url      = "https://github.com/eic/eic-smear"
+    git      = "https://github.com/eic/eic-smear.git"
 
     maintainers = ['wdconinc']
 
     variant("pythia6", default=False, description="Include Pythia6 support")
 
     version('master', branch='master')
+    version('1.1.0-rc1',  branch='1.1.0-rc1')
     version('1.0.4',  branch='1.0.4')
     version('1.0.3',  branch='1.0.3')
     version('1.0.2',  branch='1.0.2')


### PR DESCRIPTION
- Added 1.1.0-rc1
- Moved from gitlab to github for source
- Moved from branches to tags for versions