### PR TITLE
Bugfix: Use `git clone --branch releases/${SPACK_VERSION}`

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -q -y file git make automake cmake gcc gcc-c++ gcc-gfortran unzi
 
 # Install spack
 ENV SPACK_VERSION v0.15
-RUN git clone --branch ${SPACK_VERSION} https://github.com/spack/spack.git /spack
+RUN git clone --branch releases/${SPACK_VERSION} https://github.com/spack/spack.git /spack && chmod -R o+t /spack
 
 # Work in /spack
 WORKDIR /spack

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -1,4 +1,3 @@
-y
 FROM centos:8
 
 # Install build essentials

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -1,3 +1,4 @@
+y
 FROM centos:8
 
 # Install build essentials
@@ -5,7 +6,7 @@ RUN yum install -q -y file git make automake cmake gcc gcc-c++ gcc-gfortran unzi
 
 # Install spack
 ENV SPACK_VERSION v0.15  
-RUN git clone --branch ${SPACK_VERSION} https://github.com/spack/spack.git /spack
+RUN git clone --branch releases/${SPACK_VERSION} https://github.com/spack/spack.git /spack
 
 # Work in /spack
 WORKDIR /spack

--- a/docker/ubuntu18.04/Dockerfile
+++ b/docker/ubuntu18.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -q \
 
 # Install spack
 ENV SPACK_VERSION v0.15  
-RUN git clone --branch ${SPACK_VERSION} https://github.com/spack/spack.git /spack
+RUN git clone --branch releases/${SPACK_VERSION} https://github.com/spack/spack.git /spack
 
 # Work in /spack
 WORKDIR /spack

--- a/docker/ubuntu19.10/Dockerfile
+++ b/docker/ubuntu19.10/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -q \
 
 # Install spack
 ENV SPACK_VERSION v0.15  
-RUN git clone --branch ${SPACK_VERSION} https://github.com/spack/spack.git /spack
+RUN git clone --branch releases/${SPACK_VERSION} https://github.com/spack/spack.git /spack
 
 # Work in /spack
 WORKDIR /spack

--- a/docker/ubuntu20.04/Dockerfile
+++ b/docker/ubuntu20.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -q \
 
 # Install spack
 ENV SPACK_VERSION v0.15
-RUN git clone --branch ${SPACK_VERSION} https://github.com/spack/spack.git /spack
+RUN git clone --branch releases/${SPACK_VERSION} https://github.com/spack/spack.git /spack
 
 # Work in /spack
 WORKDIR /spack


### PR DESCRIPTION
Previously this seems it has been failing the travis builds since it doesn't load the right branch, https://travis-ci.org/github/eic/eic-spack/branches, but somehow didn't email me... 