### PR TITLE
[eic-smear] conflicts -pythia6 when @1.1.0-rc1

### DIFF
--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -28,10 +28,14 @@ class EicSmear(CMakePackage):
     version('1.0.1',      sha256='60b4222e41c6cf5c9cbb30c85e388ce06f1e585c5a970d34ef4d1394c058ccdc')
     version('1.0.0',      sha256='be994c94b5b665f3802723a51e5983a0d9221ca3b13138146d68ba48eb0b2d93')
 
-    depends_on('root')
+    depends_on('root +pythia6', when='+pythia6')
+    depends_on('root',          when='-pythia6')
     depends_on('zlib')
     depends_on('cmake', type='build')
     depends_on('pythia6', when='+pythia6')
+
+    conflicts('-pythia6', when='@1.1.0-rc1',
+          msg='eic-smear@1.1.0-rc1 cannot be built without pythia6.')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
eic-smear@1.1.0-rc1 cannot be built without pythia6