### PR TITLE
[py-smear] New package, py-smear@0.1.6

### DIFF
--- a/packages/py-smear/package.py
+++ b/packages/py-smear/package.py
@@ -17,4 +17,4 @@ class PySmear(PythonPackage):
 
     version('0.1.6', sha256='29bf782a318657198e26a22fe1b7fd65b2784458e724eed6b664eade85db70e6')
 
-    depends_on('py-setuptools')
+    depends_on('py-setuptools', type='build')

--- a/packages/py-smear/package.py
+++ b/packages/py-smear/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PySmear(PythonPackage):
+    """Simple command line interface to eic-smear and jleic-smear
+    particle smearing engines."""
+
+    homepage = "https://gitlab.com/eic/escalate/smear"
+    url      = "https://files.pythonhosted.org/packages/81/b9/be65c5adaf171392e87a3d5d50004a9b5d7f1412a0c6011145508e90f28c/smear-0.1.6.tar.gz"
+
+    maintainers = ['wdconinc']
+
+    version('0.1.6', sha256='29bf782a318657198e26a22fe1b7fd65b2784458e724eed6b664eade85db70e6')
+
+    depends_on('py-setuptools')


### PR DESCRIPTION
Currently depends_on py-setuptools, but that may be a type='build' dependency only.