### PR TITLE
[eic-smear] Remove 1.1.0-rc? since tag not supported

### DIFF
--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -20,8 +20,6 @@ class EicSmear(CMakePackage):
 
     version('master', branch='master')
     version('1.1.0',      sha256='9d2c37e389c588208c16c93aac0e6f5f36a141f4dbab07d2ced1c71e19378ef3')
-    version('1.1.0-rc2',  sha256='c7b0f940c5d0f812cc4fe319e2ee6a43cd248437f6a0c616db1bf6c167e001dd')
-    version('1.1.0-rc1',  sha256='e3da232320522fb078f8795ee31f06032bae454ccc7c9368e393c94ab4b88db0')
     version('1.0.4-fix1', sha256='ae312f4440b7ec5eeda75631bea209d733186199eaa3cd76c757ba1337679392')
     version('1.0.4',      sha256='7d12a1d8b1c490502cd73737e1ce264880b04e74c16ee3b27cabad371c5b9e73')
     version('1.0.3',      sha256='74b0e7a690b8fe81eb2e2ea78f96cb75aadca1c8b08450e89a7ebf8963a4d44c')


### PR DESCRIPTION
Removing eic-smear release candidates since spack does not understand that 1.1.0-rc1 < 1.1.0. No more release candidates will be supported in spack, @kkauder, sorry :-)

Alternatives considered: writing a patch for spack. Probably considered too seriously for release candidates.