### PR TITLE
[ejana] depends_on acts,genfit only when +acts,+genfit

### DIFF
--- a/packages/ejana/package.py
+++ b/packages/ejana/package.py
@@ -31,11 +31,8 @@ class Ejana(CMakePackage):
     depends_on('genfit', when='+genfit')
     depends_on('eic-smear')
 
-    # FIXME acts should be variant only
-    depends_on('acts +identification +tgeo')
-
-    # FIXME genfit should be variant only
-    depends_on('genfit')
+    depends_on('acts +identification +tgeo', when='+acts')
+    depends_on('genfit', when='+genfit')
 
     def cmake_args(self):
         args = []
@@ -48,15 +45,9 @@ class Ejana(CMakePackage):
             self.spec['hepmc3'].prefix))
         args.append('-DEIC_SMEAR_DIR={0}'.format(
             self.spec['eic-smear'].prefix))
-        # FIXME acts should be variant only
-        args.append('-DActs_DIR={0}'.format(
-            self.spec['acts'].prefix))
         if '+acts' in self.spec:
             args.append('-DActs_DIR={0}'.format(
                 self.spec['acts'].prefix))
-        # FIXME genfit should be variant only
-        args.append('-DGENFIT_DIR={0}'.format(
-            self.spec['genfit'].prefix))
         if '+genfit' in self.spec:
             args.append('-DGENFIT_DIR={0}'.format(
                 self.spec['genfit'].prefix))


### PR DESCRIPTION
This resolves the remaining FIXMEs in ejana. Now ejana will properly propagate the acts and genfit dependencies and cmake arguments only when the variants are active.