### PR TITLE
[escalate] depends_on jana2 again, with +root but not +zmq since #55

### DIFF
--- a/packages/ejana/package.py
+++ b/packages/ejana/package.py
@@ -24,7 +24,7 @@ class Ejana(CMakePackage):
     variant('genfit', default=False, description='Use genfit')
 
     depends_on('cmake@3.9:', type='build')
-    depends_on('jana2')
+    depends_on('jana2 +root')
     depends_on('hepmc3')
     depends_on('root@6.00.00:')
     depends_on('acts', when='+acts')

--- a/packages/escalate/package.py
+++ b/packages/escalate/package.py
@@ -40,7 +40,7 @@ class Escalate(BundlePackage):
     depends_on('eic-smear +pythia6', when='@develop')
     depends_on('ejana +acts +genfit', when='@develop')
     depends_on('g4e', when='@develop')
-    #depends_on('jana2 +root +zmq', when='@develop')
+    depends_on('jana2 +root', when='@develop')
     # EicRoot
     depends_on('eicroot@master')
     depends_on('eictoymodel@master')
@@ -80,7 +80,7 @@ class Escalate(BundlePackage):
     depends_on('eic-smear@1.0.4-fix1 +pythia6', when='@1.1.0')
     depends_on('ejana@1.2.3 +acts +genfit', when='@1.1.0')
     depends_on('g4e@1.3.5 +compat', when='@1.1.0')
-    #depends_on('jana2@2.0.3 +root +zmq', when='@1.1.0')
+    depends_on('jana2@2.0.3 +root', when='@1.1.0')
     # EicRoot
     depends_on('eicroot@master')
     depends_on('eictoymodel@master')
@@ -118,7 +118,7 @@ class Escalate(BundlePackage):
     depends_on('eic-smear@1.0.4-fix1 +pythia6', when='@1.0.1')
     depends_on('ejana@1.2.2 +acts +genfit', when='@1.0.1')
     depends_on('g4e@1.3.4 +compat', when='@1.0.1')
-    #depends_on('jana2@2.0.2 +root +zmq', when='@1.0.1')
+    depends_on('jana2@2.0.2 +root', when='@1.0.1')
     # EicRoot
     depends_on('eicroot@master')
     depends_on('eictoymodel@master')


### PR DESCRIPTION
Until #55 is resolved and zmq can be active, we just disable zmq in the jana2 install. This now allows escalate to be installed without dependency graph hints.