### PR TITLE
G4E v1.3.8 + better cppstd handling

### DIFF
--- a/packages/g4e/package.py
+++ b/packages/g4e/package.py
@@ -17,6 +17,7 @@ class G4e(CMakePackage):
     maintainer = ["DraTeots"]
 
     version('master',  branch='master')
+    version('1.3.8', sha256='451dee2ae8e1f0824d4f0ed7672aaad5e2b76dd3a5a95e38f2820eb51ec216c6')
     version('1.3.7', sha256='98f5387f8169ec922a162d6073544c231e3989fe7a8e5cc2e3582cbc8f312095')
     version('1.3.6', sha256='051ce2b1ff87df314a6395c22b33da19e1555caddd94d3863687101cdafad72b')
     version('1.3.5', sha256='e92d95df4b873bff3dff9fcff8a5535410a19004ae00c4a166f3adab8bd90279')
@@ -45,8 +46,7 @@ class G4e(CMakePackage):
         # >oO debug: from ppretty import ppretty
         # >oO debug: print(ppretty(self, seq_length=20))
 
-        args.append('-DCMAKE_CXX_STANDARD=17')
-
+        args.append('-DCMAKE_CXX_STANDARD={}'.format(self.spec['root'].variants['cxxstd'].value))
         args.append('-DGEANT4_DIR={0}'.format(self.spec['geant4'].prefix))
         args.append('-DVGM_DIRECTORY={0}'.format(self.spec['vgm'].prefix))
         args.append('-DHEPMC_DIRECTORY={0}'.format(self.spec['hepmc'].prefix))


### PR DESCRIPTION
G4E v 1.3.8 fixed the important bug in Beagle event weight
Now G4E spack script looks at root C++11-17 version 