### PR TITLE
[environments] use gcc@9.3.0 on centos8 and ubuntu18.04 for acts

### DIFF
--- a/environments/eic/spack.yaml
+++ b/environments/eic/spack.yaml
@@ -10,11 +10,11 @@ spack:
     when: os == 'centos7'
   - oses: [os=centos8]
     when: os == 'centos8'
-  - compilers: [gcc@8.3.1]
+  - compilers: [gcc@9.3.0]
     when: os == 'centos8'
   - oses: [os=ubuntu18.04]
     when: os == 'ubuntu18.04'
-  - compilers: [gcc@7.5.0]
+  - compilers: [gcc@9.3.0]
     when: os == 'ubuntu18.04'
   - oses: [os=ubuntu20.04]
     when: os == 'ubuntu20.04'

--- a/environments/eicroot/spack.yaml
+++ b/environments/eicroot/spack.yaml
@@ -10,11 +10,11 @@ spack:
     when: os == 'centos7'
   - oses: [os=centos8]
     when: os == 'centos8'
-  - compilers: [gcc@8.3.1]
+  - compilers: [gcc@9.3.0]
     when: os == 'centos8'
   - oses: [os=ubuntu18.04]
     when: os == 'ubuntu18.04'
-  - compilers: [gcc@7.5.0]
+  - compilers: [gcc@9.3.0]
     when: os == 'ubuntu18.04'
   - oses: [os=ubuntu20.04]
     when: os == 'ubuntu20.04'

--- a/environments/escalate/spack.yaml
+++ b/environments/escalate/spack.yaml
@@ -10,11 +10,11 @@ spack:
     when: os == 'centos7'
   - oses: [os=centos8]
     when: os == 'centos8'
-  - compilers: [gcc@8.3.1]
+  - compilers: [gcc@9.3.0]
     when: os == 'centos8'
   - oses: [os=ubuntu18.04]
     when: os == 'ubuntu18.04'
-  - compilers: [gcc@7.5.0]
+  - compilers: [gcc@9.3.0]
     when: os == 'ubuntu18.04'
   - oses: [os=ubuntu20.04]
     when: os == 'ubuntu20.04'

--- a/environments/test/spack.yaml
+++ b/environments/test/spack.yaml
@@ -12,11 +12,11 @@ spack:
     when: os == 'centos7'
   - oses: [os=centos8]
     when: os == 'centos8'
-  - compilers: [gcc@8.3.1]
+  - compilers: [gcc@9.3.0]
     when: os == 'centos8'
   - oses: [os=ubuntu18.04]
     when: os == 'ubuntu18.04'
-  - compilers: [gcc@7.5.0]
+  - compilers: [gcc@9.3.0]
     when: os == 'ubuntu18.04'
   - oses: [os=ubuntu20.04]
     when: os == 'ubuntu20.04'


### PR DESCRIPTION
Acts needs a gcc more recent than what comes with ubuntu18.04 (https://github.com/spack/spack/pull/19881) so I had to bump it up. I used the opportunity to push all systems to 9.3.0 or more recent (if a more recent system compiler is available, ubuntu20.10).