### PR TITLE
[environments] install_missing_compilers: true; add compiler matrix

### DIFF
--- a/environments/eic/spack.yaml
+++ b/environments/eic/spack.yaml
@@ -2,15 +2,27 @@ spack:
   definitions:
   - packages:
     - eic ^root -gminimal
+  - speclist:
+    - $packages
+  - when: re.search(r'cvmfswrite', hostname)
+    compilers:
+    - gcc@9.3.0  os=rhel7
+    - gcc@9.3.0  os=centos7
+    - gcc@9.3.0  os=centos8
+    - gcc@9.3.0  os=ubuntu18.04
+    - gcc@9.3.0  os=ubuntu20.04
+    - gcc@10.2.0 os=ubuntu20.10
+  - when: re.search(r'cvmfswrite', hostname)
+    speclist:
+    - matrix:
+      - [$packages]
+      - [$%compilers]
   specs:
-  - matrix:
-    - - $packages
+  - $speclist
+  config:
+    install_missing_compilers: true
   packages:
     all:
-      compiler: []
       target:
       - x86_64
-      buildable: true
-      version: []
-      providers: {}
   view: false

--- a/environments/eicroot/spack.yaml
+++ b/environments/eicroot/spack.yaml
@@ -2,15 +2,27 @@ spack:
   definitions:
   - packages:
     - eicroot ^root -gminimal
+  - speclist:
+    - $packages
+  - when: re.search(r'cvmfswrite', hostname)
+    compilers:
+    - gcc@9.3.0  os=rhel7
+    - gcc@9.3.0  os=centos7
+    - gcc@9.3.0  os=centos8
+    - gcc@9.3.0  os=ubuntu18.04
+    - gcc@9.3.0  os=ubuntu20.04
+    - gcc@10.2.0 os=ubuntu20.10
+  - when: re.search(r'cvmfswrite', hostname)
+    speclist:
+    - matrix:
+      - [$packages]
+      - [$%compilers]
   specs:
-  - matrix:
-    - - $packages
+  - $speclist
+  config:
+    install_missing_compilers: true
   packages:
     all:
-      compiler: []
       target:
       - x86_64
-      buildable: true
-      version: []
-      providers: {}
   view: false

--- a/environments/escalate/spack.yaml
+++ b/environments/escalate/spack.yaml
@@ -5,15 +5,27 @@ spack:
       +opengl +qt cxxstd=17 ^xerces-c cxxstd=17 ^clhep cxxstd=17 ^hepmc3 +interfaces
       +python +rootio ^pythia6 +root ^eic-smear +pythia6 ^ejana +acts +genfit ^jana2
       +root
+  - speclist:
+    - $packages
+  - when: re.search(r'cvmfswrite', hostname)
+    compilers:
+    - gcc@9.3.0  os=rhel7
+    - gcc@9.3.0  os=centos7
+    - gcc@9.3.0  os=centos8
+    - gcc@9.3.0  os=ubuntu18.04
+    - gcc@9.3.0  os=ubuntu20.04
+    - gcc@10.2.0 os=ubuntu20.10
+  - when: re.search(r'cvmfswrite', hostname)
+    speclist:
+    - matrix:
+      - [$packages]
+      - [$%compilers]
   specs:
-  - matrix:
-    - - $packages
+  - $speclist
+  config:
+    install_missing_compilers: true
   packages:
     all:
-      compiler: []
       target:
       - x86_64
-      buildable: true
-      version: []
-      providers: {}
   view: false

--- a/environments/test/spack.yaml
+++ b/environments/test/spack.yaml
@@ -2,15 +2,27 @@ spack:
   definitions:
   - packages:
     - escalate
+  - speclist:
+    - $packages
+  - when: re.search(r'cvmfswrite', hostname)
+    compilers:
+    - gcc@9.3.0  os=rhel7
+    - gcc@9.3.0  os=centos7
+    - gcc@9.3.0  os=centos8
+    - gcc@9.3.0  os=ubuntu18.04
+    - gcc@9.3.0  os=ubuntu20.04
+    - gcc@10.2.0 os=ubuntu20.10
+  - when: re.search(r'cvmfswrite', hostname)
+    speclist:
+    - matrix:
+      - [$packages]
+      - [$%compilers]
   specs:
-  - matrix:
-    - - $packages
+  - $speclist
+  config:
+    install_missing_compilers: true
   packages:
     all:
-      compiler: []
       target:
       - x86_64
-      buildable: true
-      version: []
-      providers: {}
   view: false


### PR DESCRIPTION
## `install_missing_compilers: true`
To ensure compilers are added to environments, we now use: 
```yaml
spack:
  config:
    install_missing_compilers: true
```
This is in the environment definition only, not the configuration defintion, so we can use it in `containerize` with compilers different from the host system compiler.

## compiler matrix for `cvmfswrite`
On hostname `cvmfswrite` we want to concretize these environments for a number of operating systems and compilers. This adds that logic.