### PR TITLE
New versions: ejana, jana2, sherpa, npdet; closes #140 

### DIFF
--- a/packages/ejana/package.py
+++ b/packages/ejana/package.py
@@ -19,6 +19,13 @@ class Ejana(CMakePackage):
     tags = ['eic']
 
     version('master', branch='master')
+    version('1.3.2', sha256='fac4ce1a78caa1588602177f02d3345e1b0e8e4d11777ee221e4265cd89992b1')
+    version('1.3.1', sha256='6005e1cdbd1fe6f65d0ebc80e8945728ad42bba3b07fee93cbc8c4b997a628db')
+    version('1.3.0', sha256='2b60c28b07ed3fa883c44cc74a3523c8ba3299fe25bdec58782910fa52f33cfb')
+    version('1.2.7', sha256='789895f79e6ca42b694a65a4de7580d3cf8686f67377215a41da247bf350aa2f')
+    version('1.2.6', sha256='88fd93bf0c063753467d8fbfa5794879a38ee82524e996782cb82d7edc94b559')
+    version('1.2.5', sha256='0496ff11df4284681458069ca133693dea1351dde22c130744129dec060456e5')
+    version('1.2.4', sha256='b43fe1b0bb6b82e190547049c6c17d5ff97d8062070eaca7872eb3b1ff7788a3')
     version('1.2.3', sha256='552bd7bd536ecb33c55cc9c1dfb3f870c253fd355456d6cca26c3665f450920d')
     version('1.2.2', sha256='d6e906591159014cbfa9a2a4ebc0354fdd8948436dddb8c3edc0bdf5d9544b69')
     version('1.2.1', sha256='80c1c16f7e350747c7980526c6c863db44c9b5dca9aadfe8e1be40e8ba352acd')

--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -18,10 +18,10 @@ class Jana2(CMakePackage):
 
     tags = ['eic']
 
-    version('2.0.3',       sha256='fd34c40e2d6660ec08aca9208999dd9c8fe17de21c144ac68b6211070463e415')
-    version('2.0.2',       sha256='161d29c2b1efbfb36ec783734b45dff178b0c6bd77a2044d5a8829ba5b389b14')
-    version('2.0.1',       sha256='1471cc9c3f396dc242f8bd5b9c8828b68c3c0b72dbd7f0cfb52a95e7e9a8cf31')
-    version('2.0.0-alpha', sha256='4a093caad5722e9ccdab3d3f9e2234e0e34ef2f29da4e032873c8e08e51e0680')
+    version('2.0.4', sha256='848adffcb881beb7835d01ce47a58991bb4f92664c9477196960ce8cfd94a3ca')
+    version('2.0.3', sha256='fd34c40e2d6660ec08aca9208999dd9c8fe17de21c144ac68b6211070463e415')
+    version('2.0.2', sha256='161d29c2b1efbfb36ec783734b45dff178b0c6bd77a2044d5a8829ba5b389b14')
+    version('2.0.1', sha256='1471cc9c3f396dc242f8bd5b9c8828b68c3c0b72dbd7f0cfb52a95e7e9a8cf31')
 
     variant('root',
             default=False,

--- a/packages/npdet/package.py
+++ b/packages/npdet/package.py
@@ -14,6 +14,8 @@ class Npdet(CMakePackage):
     tags = ['eic']
 
     version('master', branch='master', preferred=True)
+    version('1.0.0', sha256='e0522dd2a6c163367e8ad4bc12ba9ad5a58d99ea151192df3ab48228a754b490')
+    version('0.9.0', sha256='0cb0e6e39956c6751b00d53e7d44007e71c41728ee97bc785664f2416fe051f4')
     version('0.8.0', sha256='89cec16c44e9ac3b009d2fbf3817b0df7dabafe1a34b0b0160183a6431a6fbed')
     version('0.7.0', sha256='d842d5571960316e76530849fa03296dc270d90da48d557bf4bd2c358538eefe')
     version('0.6.0', sha256='0b1adbb3aff5d8b8ef9c6e81ec63721bdf12f4c457465bfd584ddeba63161edd')

--- a/packages/sherpa/package.py
+++ b/packages/sherpa/package.py
@@ -20,7 +20,25 @@ class Sherpa(AutotoolsPackage):
 
     maintainers = ['wdconinc']
 
-    version('2.2.10', branch='rel-2-2-10')
+    version('2.2.11', sha256='5e12761988b41429f1d104f84fdf352775d233cde7a165eb64e14dcc20c3e1bd')
+    version('2.2.10', sha256='ae23bc8fdcc9f8c26becc41692822233b62203cd72a7e0dab2ca19316aa0aad7')
+    version('2.2.9', sha256='ebc836d42269a0c4049d3fc439a983d19d12595d9a06db2d18765bd1e301923e')
+    version('2.2.8', sha256='ff198cbae5de445e6fe383151021ef24b1628dffc0da6bf3737753f6672a0091')
+    version('2.0.0', sha256='0e873b27bb1be46ca5ed451d1b8514ca84c10221057b11be5952180076e6f848')
+    version('1.3.1', sha256='31881207838d341358db64e3fdadfeee1ea2f6d1cb42f370014f622f579159ae')
+    version('1.3.0', sha256='08b13c65b66f2edde6996d2a06762a12a0682ffb64bca43654df47321e5039a0')
+    version('1.2.3', sha256='029727337a430d6675a1a12dce3ced0411041e79ddaf4ce3b9466035cf6c8804')
+    version('1.2.2', sha256='6e7b5ea80b99f1378519009e494030d6cf4c4491f91218d749eabb8ffaad9ac1')
+    version('1.2.1', sha256='838462f4a1e8768135363aa6b8532fd8f5e5789a269b858f8e3728ab37f6a1d1')
+    version('1.2.0', sha256='509508fd0ad72aaf55ab484da8b6bc0b31688c955adcda62a3e8f94689cebf99')
+    version('1.1.3', sha256='6335e5eb1fc304e9618496d3ddb198b3591e57b27db6e876af8fd649a8b98c93')
+    version('1.1.2', sha256='e1689cad6700dc013af0afb0d33729ac2b5e9841d2f325c85b10d773e7f8a80e')
+    version('1.1.1', sha256='b80e1d75934be79b73400d2c95d96e88651626ea29ddcb9d8fde9c1812039e29')
+    version('1.1.0', sha256='8052d137d668353dc710f8691b921e772820d39e20361f0d616ee2da1ac798f2')
+    version('1.0.9', sha256='fe28db91ea8264364395c7e5efeeae3e5c01ea1343e0db7fe13924c6f17fb963')
+    version('1.0.8', sha256='6e346bafd13b5b05ad566a73759da6d5e64d65c5036780cc4911d93277e891fa')
+    version('1.0.7', sha256='d1eeefd96c6822ea8eb926447ca91ec4a1c714e4746323e92b1e17764e51ff0b')
+    version('1.0.6', sha256='358d417ec3afde24618c222bc9b742bc5102d435622b3cd6f2e3f72d03656255')
 
     _cxxstd_values = ('11', '14', '17')
     variant('cxxstd',    default='11', values=_cxxstd_values, multi=False,


### PR DESCRIPTION
Closes #140.