### PR TITLE
eicd depends_on emd4hep; athena-eic@master depends_on @master

### DIFF
--- a/packages/athena-eic/package.py
+++ b/packages/athena-eic/package.py
@@ -27,8 +27,12 @@ class AthenaEic(CMakePackage):
 
     depends_on('dd4hep +ddg4 +hepmc3')
     depends_on('acts +dd4hep +identification +tgeo')
+
     depends_on('athena-ip6', when='ip=6')
+    depends_on('athena-ip6@master', when='@master ip=6')
+
     depends_on('juggler', when='+reconstruction')
+    depends_on('juggler@master', when='@master +reconstruction')
 
     phases = ['cmake', 'build', 'install', 'postinstall']
 

--- a/packages/eicd/package.py
+++ b/packages/eicd/package.py
@@ -24,5 +24,6 @@ class Eicd(CMakePackage):
     version('0.2.0', sha256='3e52e19bdfbda67454786080db678107a00b932b4cf26bfd95bbf764cc1f7fc9')
     version('0.1.0', sha256='814eec1b6c27e46fdedfd3f42d846366c6170c3b1c7b5225c28465d0861b612c')
 
+    depends_on('edm4hep')
     depends_on('podio@0.11.0:')
     depends_on('root')

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -33,18 +33,25 @@ class Juggler(CMakePackage):
     version('1.6.0', sha256='dca4f824a1c1d360b4bd795e6fb0353b8729318a3a0781a8ae0dcf745ae82f02')
     version('1.5.0', sha256='e2fe06730949766a32b08200101822fe8a145634fa46b09c6057cb321350cf57')
 
-    depends_on('gaudi', when='@master')
-    depends_on('gaudi@36', when='@2:')
-    depends_on('gaudi@33:34', when='@:1.8')
-    depends_on('acts +identification +json +tgeo +dd4hep')
-    depends_on('acts@15.1:17', when='@5') 
-    depends_on('acts@9:14', when='@4')
-    depends_on('acts@8', when='@3')
-    depends_on('podio@0.11.0:')
-    depends_on('npdet')
-    depends_on('eicd')
     depends_on('root')
     depends_on('geant4')
     depends_on('genfit')
     depends_on('dd4hep +ddg4')
+    depends_on('tensorflow-lite')
 
+    depends_on('gaudi', when='@master')
+    depends_on('gaudi@36', when='@2:')
+    depends_on('gaudi@33:34', when='@:1.8')
+    
+    depends_on('acts +identification +json +tgeo +dd4hep')
+    depends_on('acts@15.1:17', when='@5') 
+    depends_on('acts@9:14', when='@4')
+    depends_on('acts@8', when='@3')
+    
+    depends_on('podio@0.11.0:')
+
+    depends_on('npdet')
+    depends_on('npdet@master', when='@master')
+    
+    depends_on('eicd')
+    depends_on('eicd@master', when='@master')


### PR DESCRIPTION
This will fail due to `depends_on('tensorflow-lite')` at this point. 