### PR TITLE
eicrecon: no depends_on ip6|epic, but edm4hep@0.5:

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -20,21 +20,7 @@ class Eicrecon(CMakePackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('jana2')
     depends_on('dd4hep')
-    depends_on('edm4hep')
-    depends_on('eic-ip6')
-    depends_on('epic-eic')
+    depends_on('edm4hep@0.5:')
     depends_on('fmt')
 
     root_cmakelists_dir = 'src'
-
-    def setup_build_environment(self, env):
-        env.set('EDM4HEP_ROOT', self.spec['edm4hep'].prefix)
-
-    def cmake_args(self):
-        args = [
-            self.define('DETECTOR_LIBS_IP6',
-                self.spec['eic-ip6'].prefix),
-            self.define('DETECTOR_LIBS_EPIC',
-                self.spec['epic-eic'].prefix),
-        ]
-        return args


### PR DESCRIPTION
The need for a dependency on eic-ip6 and epic-eic will be removed, and there is a hard dependency on edm4hep of at least version 0.5.