### PR TITLE
jana2: new version 2.0.7

### DIFF
--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -19,6 +19,7 @@ class Jana2(CMakePackage):
     tags = ['eic']
 
     version('master', branch='master')
+    version("2.0.7", sha256="56b4d1858d0f84e655b903eef07f5c6e23a9ed62219cd083ae279549dd051eb1")
     version('2.0.6', sha256='122ceba6e9541949803073b6e51fb594500132cf7535808d635bdc193e95a9e2')
     version('2.0.5', sha256='2e7297dfb0bd7f4a2f2fa3bca6b1c10b2553d321dec6060e48b0d75a5ed6717d')
     version('2.0.4', sha256='848adffcb881beb7835d01ce47a58991bb4f92664c9477196960ce8cfd94a3ca')


### PR DESCRIPTION
No build system changes.