### PR TITLE
dd4hep: backport 1.21 to v0.18

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -1,0 +1,6 @@
+from spack import *
+from spack.pkg.builtin.dd4hep import Dd4hep as BuiltinDd4hep
+
+
+class Dd4hep(BuiltinDd4hep):
+    version("1.21", sha256="0f9fe9784bf28fa20ce5555ff074430da430e9becc2566fe11e27c4904a51c94")


### PR DESCRIPTION
Necessary for acts 20.0.0