### PR TITLE
EDM4eic dependency in juggler

### DIFF
--- a/packages/edm4eic/package.py
+++ b/packages/edm4eic/package.py
@@ -14,6 +14,8 @@ class Edm4eic(CMakePackage):
     tags = ['eic']
 
     version('main', branch='main')
+    version("1.1.0", sha256="f50a6ef77d8247aa30da5b1e574bb24ab82c86c8706a8f3900ff151dafe9a754")
+    version("1.0.1", sha256="683dcd463757f9e4ad47e493be1f5fb40a6c1aae7d249ff18a19367384a61070")
     version("1.0.0", sha256="700ae7453f16786db4d3ace1a146914e1f0b935a08039c9f1f6a5ebe4aa173ae")
 
     variant('cxxstd',
@@ -29,6 +31,7 @@ class Edm4eic(CMakePackage):
 
     depends_on('edm4hep@0.4.1:', when='@1:')
     depends_on('podio@0.15:', when='@1:')
+    depends_on("cli11", when="@1.1:")
     depends_on('root@6.08:')
 
     def cmake_args(self):

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -14,6 +14,8 @@ class Juggler(CMakePackage):
     tags = ['eic']
 
     version('master', branch='master')
+    version("8.0.1", sha256="c85f633ca17f9690aed9a30592efbadd0b2223d8064d9dd01de29988402812ea")
+    version("8.0.0", sha256="498734a4e776e2ab9b6adafa827ca2f09895e64dbf6685281d4b894ed123566b")
     version('7.0.0', sha256='c30cf91d7424340f2b36093a3538d25c700f2191cd0da0d3dccfa83bdc996826')
     version('6.1.0', sha256='1ab310910f7e8f6178edc994b66305bf4b3cb4a6eaa93833b662155008e2b119')
     version('6.0.0', sha256='645fc7a45fa73f154b7919d292d9d5b8a864df488a8526c054edb18b90c1fd99')
@@ -62,9 +64,11 @@ class Juggler(CMakePackage):
 
     depends_on('edm4hep')
 
-    depends_on('eicd')
+    depends_on('eicd', when="@:7")
     depends_on('eicd@master', when='@master')
     depends_on('eicd@2:', when='@6:')
+
+    depends_on("edm4eic", when="@8:")
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New juggler versions 8.0.0 and 8.0.1 depend on EDM4eic (which also has new versions).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Newer versions for juggler, edm4eic may be installed. New package cli11 may be installed.