### PR TITLE
juggler: add main branch, deprecate master branch

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -13,7 +13,8 @@ class Juggler(CMakePackage):
 
     tags = ['eic']
 
-    version('master', branch='master')
+    version('main', branch='main')
+    version('master', branch='master', deprecated=True)
     version("8.0.1", sha256="c85f633ca17f9690aed9a30592efbadd0b2223d8064d9dd01de29988402812ea")
     version("8.0.0", sha256="498734a4e776e2ab9b6adafa827ca2f09895e64dbf6685281d4b894ed123566b")
     version('7.0.0', sha256='c30cf91d7424340f2b36093a3538d25c700f2191cd0da0d3dccfa83bdc996826')


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Using `main` instead of `master` has been rolling out [worldwide](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) and in EIC software land, mainly when moving from eicweb to GitHub, but we should be consistent also with projects that are staying on eicweb.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators: deprecation warning will appear

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. Deprecation warning for those using `master`.

### Does this PR change default behavior?
No. `main` (as previously with `master`) needs to specified explicitly.