### PR TITLE
juggler: now main, not master, and depends_on cppgsl

### DIFF
--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -30,7 +30,7 @@ class EpicEic(CMakePackage):
     depends_on('eic-ip6@master', when='@main ip=6')
 
     depends_on('juggler', when='+reconstruction')
-    depends_on('juggler@master', when='@main +reconstruction')
+    depends_on('juggler@main', when='@main +reconstruction')
 
     phases = ['cmake', 'build', 'install', 'postinstall']
 

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -71,6 +71,8 @@ class Juggler(CMakePackage):
 
     depends_on("edm4eic", when="@8:")
 
+    depends_on("cppgsl")
+
     def cmake_args(self):
         args = []
         # C++ Standard


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Juggler now depend on `cppgsl`, and the `master` branch was renamed to `main`. While `master` still exists, it is frozen and unsupported.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. Those who have `juggler@master` in environments will need to change this. An error will appear indicating that `juggler@master` is not an available version.

### Does this PR change default behavior?
Yes. Juggler will now pull in `cppgsl`.