### PR TITLE
fix: eicrecon should not depend on `acts +edm4hep` if `-examples`

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -26,6 +26,6 @@ class Eicrecon(CMakePackage):
     depends_on('edm4eic')
     depends_on('edm4hep')
     depends_on('podio')
-    depends_on('acts +dd4hep +edm4hep +identification +tgeo')
+    depends_on('acts +dd4hep +identification +tgeo')
     depends_on('root')
     depends_on('fmt')


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The variant `edm4hep` only affects examples, not actual code, so `eicrecon` should not depend on it.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.