### PR TITLE
dd4hep: include G4TessellatedSolid closure patch (backport into v0.18)

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -11,3 +11,8 @@ class Dd4hep(BuiltinDd4hep):
         sha256="28fb1c17eb1c06c24b304511308fd3b0af708f2ba3aec3e4cb13d7da6abbc51c",
         when="@1.21:1.22",
     )
+    patch(
+        "https://github.com/AIDASoft/DD4hep/pull/983.patch?full_index=1",
+        sha256="969fbdd9a35a07fe91d6376517621d3ddba28f13668d139fd9405052e3e6f1a6",
+        when="@:1.23",
+    )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add dd4hep patch to set tessellated solid closure flag in geant4 solids.

### What kind of change does this PR introduce?
- [X]  Bug fix (issue epic geometry hcal implementation)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @johnlajoie 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, adds patch to default dd4hep version.