### PR TITLE
eicrecon: depends_on spdlog (backport to v0.18)

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -29,3 +29,4 @@ class Eicrecon(CMakePackage):
     depends_on('acts +dd4hep +identification +tgeo')
     depends_on('root')
     depends_on('fmt')
+    depends_on("spdlog")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
eicrecon should explicitly depend on spdlog.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: build failures when not using view)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.