### PR TITLE
fix: 3.2.5 patch fails on 3.2.4; use URL for patch

### DIFF
--- a/packages/hepmc3/package.py
+++ b/packages/hepmc3/package.py
@@ -2,6 +2,6 @@ from spack import *
 from spack.pkg.builtin.hepmc3 import Hepmc3 as BuiltinHepmc3
 class Hepmc3(BuiltinHepmc3):
     version("3.2.5", sha256="cd0f75c80f75549c59cc2a829ece7601c77de97cb2a5ab75790cac8e1d585032")
-    patch('ReaderPlugin.patch',
-          sha256='66354530bea9f68a1eb5a1fcceb829e5df6844ee0e0ea67aec2af55d5e4cfa78',
-          when='@:3.2.5')
+    patch('https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/188.diff',
+          sha256='775f312a72cc900751290f5a474ddccd9b8bf5bc37b6ac5c11da8dc2d9e1c561',
+          when='@3.2.5')


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This restricts the version range to patch for skipping of events, and uses the upstream URL for the patch.
