### PR TITLE
hepmc3: redefined cmake_args for v0.18 to find python_platlib

### DIFF
--- a/packages/hepmc3/package.py
+++ b/packages/hepmc3/package.py
@@ -5,3 +5,27 @@ class Hepmc3(BuiltinHepmc3):
     patch('ReaderPlugin.patch',
           sha256='66354530bea9f68a1eb5a1fcceb829e5df6844ee0e0ea67aec2af55d5e4cfa78',
           when='@3.2.5')
+
+    # copy over cmake_args to resolve https://github.com/spack/spack/issues/31648
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            "-DHEPMC3_ENABLE_PYTHON={0}".format(spec.satisfies("+python")),
+            "-DHEPMC3_ENABLE_ROOTIO={0}".format(spec.satisfies("+rootio")),
+            "-DHEPMC3_INSTALL_INTERFACES={0}".format(spec.satisfies("+interfaces")),
+        ]
+
+        if self.spec.satisfies("+python"):
+            py_ver = spec["python"].version.up_to(2)
+            args.extend(
+                [
+                    "-DHEPMC3_PYTHON_VERSIONS={0}".format(py_ver),
+                    "-DHEPMC3_Python_SITEARCH{0}={1}".format(py_ver.joined, python_platlib),
+                ]
+            )
+
+        if self.spec.satisfies("+rootio"):
+            args.append("-DROOT_DIR={0}".format(self.spec["root"].prefix))
+        args.append("-DHEPMC3_ENABLE_TEST={0}".format(self.run_tests))
+        return args
+


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We cannot use the inherited cmake_args function since python_platlib is only avialable in the module, not the inheritance tree.