### PR TITLE
EDM4eic 1.2.1 backport to v0.18

### DIFF
--- a/packages/edm4eic/package.py
+++ b/packages/edm4eic/package.py
@@ -14,6 +14,7 @@ class Edm4eic(CMakePackage):
     tags = ['eic']
 
     version('main', branch='main')
+    version("1.2.1", sha256="8349864f5c923e991d31462cc7987cd39c050910d4db8847575c8d4fd61967a5")
     version("1.2.0", sha256="e70ec6d2a93002237c1bfd0046e96f3838f9dab3f5326bdb17826999b5f42759")
     version("1.1.0", sha256="f50a6ef77d8247aa30da5b1e574bb24ab82c86c8706a8f3900ff151dafe9a754")
     version("1.0.1", sha256="683dcd463757f9e4ad47e493be1f5fb40a6c1aae7d249ff18a19367384a61070")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New version 1.2.1 of edm4eic, backport to v0.18.