### PR TITLE
dd4hep: two patches to support hepmc3 files on xrootd servers

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -13,3 +13,13 @@ class Dd4hep(BuiltinDd4hep):
         sha256="969fbdd9a35a07fe91d6376517621d3ddba28f13668d139fd9405052e3e6f1a6",
         when="@:1.23",
     )
+    patch(
+        "https://github.com/AIDASoft/DD4hep/pull/989.patch?full_index=1",
+        sha256="b29bec9faac4461f799f0ed12b85bf929ae4126fbf591fa8e2cca51fffae12e7",
+        when="@1.23",
+    )
+    patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1011.patch?full_index=1",
+        sha256="15f4b9cc6e36aea836191b2154c0609a1ab55f085a0836609dfca804cbe78c6d",
+        when="@1.23",
+    )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds support for `.hepmc3` and `.hepmc3.tree.root` extensions in ddsim.