### PR TITLE
root: patch for spurious gdml overlaps

### DIFF
--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -1,0 +1,10 @@
+from spack import *
+from spack.pkg.builtin.root import Root as BuiltinRoot
+
+
+class Root(BuiltinRoot):
+    patch(
+        "https://github.com/root-project/root/pull/11788.patch?full_index=1",
+        sha256="89294c428c679d4850f999df89f83c26a86b2dd410fb0cd3941bda0bca07dc32",
+        when="@6.06.00:6.26.10",
+    )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Patch ROOT to avoid gdml tessellated solid overlap checks.
