### PR TITLE
eic-smear: depends_on hepmc3

### DIFF
--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -86,6 +86,7 @@ class EicSmear(CMakePackage):
     depends_on("root +pythia6", when="+pythia6")
     depends_on("root", when="-pythia6")
     depends_on("zlib")
+    depends_on("hepmc3")
     depends_on("cmake", type="build")
     depends_on("pythia6", when="+pythia6")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
eic-smear depends on hepmc3.