### PR TITLE
edm4hep: new version 0.7.1, 0.7.2

### DIFF
--- a/packages/edm4hep/package.py
+++ b/packages/edm4hep/package.py
@@ -1,0 +1,7 @@
+from spack import *
+from spack.pkg.builtin.edm4hep import Edm4hep as BuiltinEdm4hep
+
+
+class Edm4hep(BuiltinEdm4hep):
+    version("0.7.2", sha256="e289280d5de2c0a3b542bf9dfe04b9f6471b0a0fcf33f5c8101ea7252e2a7643")
+    version("0.7.1", sha256="82e215a532f548a73a6f6094eaa8b436c553994e135f6d63a674543dc89a9f1b")


### PR DESCRIPTION
edm4hep: new versions 0.7.1, 0.7.2, which includes the edm4hep2json exporter