### PR TITLE
harfbuzz: new version 5.3.1

### DIFF
--- a/packages/harfbuzz/package.py
+++ b/packages/harfbuzz/package.py
@@ -1,0 +1,6 @@
+from spack import *
+from spack.pkg.builtin.harfbuzz import Harfbuzz as BuiltinHarfbuzz
+
+
+class Harfbuzz(BuiltinHarfbuzz):
+    version("5.3.1", sha256="4a6ce097b75a8121facc4ba83b5b083bfec657f45b003cd5a3424f2ae6b4434d")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Harfbuzz is a dependency of qt, geant4, etc. The current most recent version in v0.19 spack fails to build on aarch64. This version addresses the build issue. It is also being upstreamed to spack, so this won't be cherry-picked into develop.