### PR TITLE
irt: new version 1.0.6

### DIFF
--- a/packages/irt/package.py
+++ b/packages/irt/package.py
@@ -18,6 +18,7 @@ class Irt(CMakePackage):
     maintainers = ["wdconinc", "c-dilks"]
     tags = ["eic"]
 
+    version("1.0.6", sha256="8a7f82548fc73fbd7ca530a7d0d30d2ef0fca2071b7e1fbfe0620789022f51d9")
     version("1.0.5", sha256="b51006ae517a685e6a1004ec0f6cd538317801319ede51f8c806d23690c7648e")
     version("1.0.4", sha256="8e0bc2542c10d208e933418265a235922dc542026aa2cb0a58d5dc838677dfac")
     version("1.0.3", sha256="b28dea9880dcf84384ede6d672bf3b598446a229faa5197e86bcaa433a0186db")
@@ -27,3 +28,12 @@ class Irt(CMakePackage):
     version("1.0.0", sha256="55746700a477ed4decbdadbc008b43f370071cdd699452b96d7daa1dbc4ee28d")
 
     depends_on("root@6: +root7")
+
+    def cmake_args(self):
+        args = [
+            "-DEVALUATION=OFF",
+            "-DDELPHES=OFF",
+        ]
+        if self.spec.satisfies('@1.0.6:'):
+            args.append("-DIRT_ROOT_IO=OFF")
+        return args

--- a/packages/irt/package.py
+++ b/packages/irt/package.py
@@ -26,6 +26,7 @@ class Irt(CMakePackage):
     version("1.0.2", sha256="9e88df94a675bccbbd679c9fccb2e3d63d23edcfc9d487f6073b39b462e841f9")
     version("1.0.1", sha256="9e916f145a5a6045a1f9ad2130538e3c58e8c2342c77da831e5021aa752dc1c3")
     version("1.0.0", sha256="55746700a477ed4decbdadbc008b43f370071cdd699452b96d7daa1dbc4ee28d")
+   variant("root_io", default=False, description="Build dictionaries for ROOT IO", when="@1.0.6:")
 
     depends_on("root@6: +root7")
 
@@ -34,6 +35,5 @@ class Irt(CMakePackage):
             "-DEVALUATION=OFF",
             "-DDELPHES=OFF",
         ]
-        if self.spec.satisfies('@1.0.6:'):
-            args.append("-DIRT_ROOT_IO=OFF")
+    args.append(self.define_from_variant("IRT_ROOT_IO", "root_io"))
         return args

--- a/packages/irt/package.py
+++ b/packages/irt/package.py
@@ -26,7 +26,8 @@ class Irt(CMakePackage):
     version("1.0.2", sha256="9e88df94a675bccbbd679c9fccb2e3d63d23edcfc9d487f6073b39b462e841f9")
     version("1.0.1", sha256="9e916f145a5a6045a1f9ad2130538e3c58e8c2342c77da831e5021aa752dc1c3")
     version("1.0.0", sha256="55746700a477ed4decbdadbc008b43f370071cdd699452b96d7daa1dbc4ee28d")
-   variant("root_io", default=False, description="Build dictionaries for ROOT IO", when="@1.0.6:")
+
+    variant("root_io", default=False, description="Build dictionaries for ROOT IO", when="@1.0.6:")
 
     depends_on("root@6: +root7")
 
@@ -35,5 +36,5 @@ class Irt(CMakePackage):
             "-DEVALUATION=OFF",
             "-DDELPHES=OFF",
         ]
-    args.append(self.define_from_variant("IRT_ROOT_IO", "root_io"))
+        args.append(self.define_from_variant("IRT_ROOT_IO", "root_io"))
         return args


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- see [release notes](https://github.com/eic/irt/releases/tag/v1.0.6)
- disables ROOT dictionary generation (`-DIRT_ROOT_IO=OFF`), since it is not needed for EICrecon and it does not seem to work well with spack builds; this will clear the errors from https://github.com/eic/EICrecon/issues/560

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no