### PR TITLE
fix: revert to pre-frame podio without deprecated `setValues`

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -17,12 +17,12 @@ class Dd4hep(BuiltinDd4hep):
     )
     patch(
         "revert-Geant4Output2EDM4hep-dd4hep-1-25-1-to-1-23.patch",
-        sha256="9ca3b458a960c1953c13b89d7869d42f945893e4764ee61cb24c15137d35ed4f",
+        sha256="1958c7951ed53538631ae6bc0d6663ea092e19f63367ed0fe1ab2bb00ddf4903",
         when="@1.25.1 -frames",
     )
     patch(
         "revert-Geant4Output2EDM4hep-dd4hep-1-24-to-1-23.patch",
-        sha256="d2077dbb83f18e9873c396309773dc0de4bf63b9b807ca464572e10ad5fa0797",
+        sha256="1c5697eabab65d4c2d49d710c14a33673e92b0349ed8299041c9da2d7878831b",
         when="@1.24 -frames",
     )
     patch(

--- a/packages/dd4hep/revert-Geant4Output2EDM4hep-dd4hep-1-24-to-1-23.patch
+++ b/packages/dd4hep/revert-Geant4Output2EDM4hep-dd4hep-1-24-to-1-23.patch
@@ -61,13 +61,13 @@ index 950f3e20..2bafbdbd 100644
 +      auto& lcparameters = event.getEventMetaData();
 +
 +      for(auto const& ival: this->intParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +      for(auto const& ival: this->fltParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +      for(auto const& ival: this->strParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +    }
 +

--- a/packages/dd4hep/revert-Geant4Output2EDM4hep-dd4hep-1-25-1-to-1-23.patch
+++ b/packages/dd4hep/revert-Geant4Output2EDM4hep-dd4hep-1-25-1-to-1-23.patch
@@ -60,13 +60,13 @@ diff --git a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp b/DDG4/edm4hep/Geant4Output2E
 +      auto& lcparameters = event.getEventMetaData();
 +
 +      for(auto const& ival: this->intParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +      for(auto const& ival: this->fltParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +      for(auto const& ival: this->strParameters()) {
-+        lcparameters.setValues(ival.first, ival.second);
++        lcparameters.setValue(ival.first, ival.second);
 +      }
 +    }
 +


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This changes the deprecated `setValues` call into a `setValue` call in the podio patch.