### PR TITLE
tensorflow-lite: new versions (untested)

### DIFF
--- a/packages/tensorflow-lite/package.py
+++ b/packages/tensorflow-lite/package.py
@@ -18,6 +18,10 @@ class TensorflowLite(CMakePackage):
 
     maintainers = ["wdconinc"]
 
+    version("2.12.0", sha256="c030cb1905bff1d2446615992aad8d8d85cbe90c4fb625cee458c63bf466bc8e")
+    version("2.11.1", sha256="624ed1cc170cdcc19e8a15d8cdde989a9a1c6b0534c90b38a6b2f06fb2963e5f")
+    version("2.10.1", sha256="622a92e22e6f3f4300ea43b3025a0b6122f1cc0e2d9233235e4c628c331a94a3")
+    version("2.9.3", sha256="59d09bd00eef6f07477eea2f50778582edd4b7b2850a396f1fd0c646b357a573")
     version(
         "2.9.1",
         sha256="6eaf86ead73e23988fe192da1db68f4d3828bcdd0f3a9dc195935e339c95dbdc",
@@ -26,6 +30,7 @@ class TensorflowLite(CMakePackage):
         "2.9.0",
         sha256="8087cb0c529f04a4bfe480e49925cd64a904ad16d8ec66b98e2aacdfd53c80ff",
     )
+    version("2.8.4", sha256="c08a222792bdbff9da299c7885561ee27b95d414d1111c426efac4ccdce92cde")
     version(
         "2.8.2",
         sha256="b3f860c02c22a30e9787e2548ca252ab289a76b7778af6e9fa763d4aafd904c7",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New versions since 2.9.1, now at 2.12