### PR TITLE
juggler, epic-eic: new versions

### DIFF
--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -14,6 +14,11 @@ class EpicEic(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
+    version("23.06.1", sha256="c78a756f84f34c6bb7b39e2bb104ffa7bcb2c7d0dcbdaa7905fe44f81e7b17aa")
+    version("23.06.0", sha256="3e9825457920b97cab1bc73f44b8cfc45130f66a5d00c4acde4f8b9079a661b1")
+    version("23.05.2", sha256="afb31d076a7859bd4cd94d9eed237f402a5cc56100c53c933ed4a024c8ef997b")
+    version("23.05.1", sha256="4cac31b2619b3aafaaa9cc6a43923a97d04d74b753eb580990d569d1ef94c94d")
+    version("23.05.0", sha256="a72774ffc3176178b128a4069d2a7bebfebde91192d971d0ccd3ab3392ff7977")
     version(
         "23.03.0",
         sha256="16badb2418531250a81931f920e145c4be9ef93411f091d93202c23e36e91129",

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -17,6 +17,7 @@ class Juggler(CMakePackage):
 
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
+    version("9.4.0", sha256="f1e76f2bd8799a0555352de472cf58c55c2ba27388ad5a8522889169b8341263")
     version(
         "9.3.0",
         sha256="2ce7c36b38a1041c1a80c2e0f16d12759881a0337eac1fcd78277093151b2b94",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Juggler 9.4.0 (legacy release) and epic geometries 23.05 and 23.06.