### PR TITLE
podio: backport PR 423, then add only commit from PR 434

### DIFF
--- a/packages/podio/package.py
+++ b/packages/podio/package.py
@@ -9,7 +9,7 @@ class Podio(BuiltinPodio):
         when="@0.16.4:0.16.5",
     )
     patch(
-        "https://github.com/AIDASoft/podio/pull/434.patch?full_index=1",
-        sha256="8150062022c2489e07dbedbf073cf7a15fec8d43c3f4c472c3ad7ecd413232fc",
+        "https://github.com/AIDASoft/podio/pull/434/commits/9f9c5fc8d40bc3e037b0846d5133d9a0e4d15c36.patch?full_index=1",
+        sha256="591aa122f55042b089303a4411418e2ac253469a8b6f6a79ebd14868fb88c1e5",
         when="@0.16.4:0.16.5",
     )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Now we use a full https://github.com/AIDASoft/podio/pull/423, and a single commit from https://github.com/AIDASoft/podio/pull/434. This should now finally work... (it does, locally)

Also, we need better CI here...