### PR TITLE
algorithms: new version main, deprecate master

### DIFF
--- a/packages/algorithms/package.py
+++ b/packages/algorithms/package.py
@@ -15,7 +15,8 @@ class Algorithms(CMakePackage):
 
     maintainers = ["wdconinc", "sly2j"]
 
-    version("master", branch="master")
+    version("main", branch="main")
+    version("master", branch="master", deprecated=True)
 
     depends_on("edm4hep")
     depends_on("edm4eic")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New version `main`. The default branch was renamed from `master` and is deprecated.
