### PR TITLE
geant4: add versions with backported eAST physics list

### DIFF
--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -3,5 +3,8 @@ from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 
 class Geant4(BuiltinGeant4):
+    ## Versions with the eAST physics list
+    version("11.1.1.east", git="https://github.com/eic/geant4", branch="east-v11.1.1")
+
     ## Add to the hardcoded GEANT4 Birk's constants
     patch("birks.patch", when="@10.7.0:")

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -4,6 +4,7 @@ from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 class Geant4(BuiltinGeant4):
     ## Versions with the eAST physics list
+    version("11.1.2.east", git="https://github.com/eic/geant4", branch="east-v11.1.2")
     version("11.1.1.east", git="https://github.com/eic/geant4", branch="east-v11.1.1")
 
     ## Add to the hardcoded GEANT4 Birk's constants


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds a version of geant4 with a backported eAST physics list.
