### PR TITLE
juggler: no depends on genfit

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -141,7 +141,7 @@ class Juggler(CMakePackage):
 
     depends_on("root")
     depends_on("geant4")
-    depends_on("genfit")
+    depends_on("genfit", when="@:8")
     depends_on("dd4hep +ddg4")
     depends_on("tensorflow-lite")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Juggler hasn't depended on genfit since v9.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.