### PR TITLE
epic-eic: rm acts, add acts-dd4hep dependencies

### DIFF
--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -67,8 +67,11 @@ class EpicEic(CMakePackage):
         description="Interaction point design",
     )
 
-    depends_on("dd4hep +ddg4 +hepmc3")
-    depends_on("acts +dd4hep +identification +tgeo")
+    depends_on("dd4hep@1.21: +ddg4 +ddrec", when="@:23.03.0")
+    depends_on("dd4hep@1.21: +ddrec", when="@23.05.0:")
+
+    depends_on("acts-dd4hep", when=@:23.01.0")
+    
     depends_on("fmt +shared")
     depends_on("py-pyyaml")
     depends_on("py-jinja2")

--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -70,7 +70,7 @@ class EpicEic(CMakePackage):
     depends_on("dd4hep@1.21: +ddg4 +ddrec", when="@:23.03.0")
     depends_on("dd4hep@1.21: +ddrec", when="@23.05.0:")
 
-    depends_on("acts-dd4hep", when=@:23.01.0")
+    depends_on("acts-dd4hep", when="@:23.01.0")
     
     depends_on("fmt +shared")
     depends_on("py-pyyaml")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the unneeded dependency of `epic-eic` on `acts`.