### PR TITLE
dd4hep: patch 1.26 to enable HepMC3FileReader XRootD reading again

### DIFF
--- a/packages/dd4hep/HepMC3FileReader-XRootD.patch
+++ b/packages/dd4hep/HepMC3FileReader-XRootD.patch
@@ -1,0 +1,33 @@
+diff --git a/DDG4/hepmc/HepMC3FileReader.cpp b/DDG4/hepmc/HepMC3FileReader.cpp
+index b94897ab..07b5505f 100644
+--- a/DDG4/hepmc/HepMC3FileReader.cpp
++++ b/DDG4/hepmc/HepMC3FileReader.cpp
+@@ -129,16 +129,18 @@ HEPMC3FileReader::HEPMC3FileReader(const std::string& nam)
+   printout(INFO,"HEPMC3FileReader","Created file reader. Try to open input %s", nam.c_str());
+   m_reader = HepMC3::deduce_reader(nam);
+ #if HEPMC3_VERSION_CODE >= 3002006
+-  // to get the runInfo in the Ascii reader we have to force HepMC to read the first event
+-  m_reader->skip(1);
+-  // then we get the run info (shared pointer)
+-  auto runInfo = m_reader->run_info();
+-  // and close the reader
+-  m_reader->close();
+-  // so we can open the file again from the start
+-  m_reader = HepMC3::deduce_reader(nam);
+-  // and set the run info object now
+-  m_reader->set_run_info(runInfo);
++  if (nam.rfind(".root") != nam.size() - 5) {
++    // to get the runInfo in the Ascii reader we have to force HepMC to read the first event
++    m_reader->skip(1);
++    // then we get the run info (shared pointer)
++    auto runInfo = m_reader->run_info();
++    // and close the reader
++    m_reader->close();
++    // so we can open the file again from the start
++    m_reader = HepMC3::deduce_reader(nam);
++    // and set the run info object now
++    m_reader->set_run_info(runInfo);
++  }
+ #endif
+   m_directAccess = false;
+ }

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -6,6 +6,10 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "HepMC3FileReader-XRootD.patch",
+        when="@=1.26",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1086.patch?full_index=1",
         sha256="6b049415e2c6989f3927ff2c56e4764de1650cad6ed301d8ac0f047f4e0039c5",
         when="@1.24:1.25.1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This patches DD4hep-1.26 to enable the HepMC3FileReader to read XRootD files again. Ref: https://github.com/AIDASoft/DD4hep/issues/1156.
