### PR TITLE
feat: updated packages for ePIC release 23.09

### DIFF
--- a/packages/edm4eic/package.py
+++ b/packages/edm4eic/package.py
@@ -15,8 +15,12 @@ class Edm4eic(CMakePackage):
 
     version("main", branch="main")
     version(
-        "2.2.0",
-        sha256="f3e6aed520d9d01606e68ab39367a2d97e0b4787b516bbedeb0149da2f8d24f2",
+        "3.0.1",
+        sha256="f5d3ed307c53a1197c71581b7095c40f9cd0afd624997a8720428d24bc0c0d60",
+    )
+    version(
+        "3.0.0",
+        sha256="dc7cc7f2af17bb90e0379487e651033e2694fa8926b6e9cb6555cc4b6a4ad255",
     )
     version(
         "2.1.0",

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -18,6 +18,46 @@ class Eicrecon(CMakePackage):
 
     version("main", branch="main")
     version(
+        "1.5.0",
+        sha256="b91339f39747ebda4e52a0e9d65e3af36e0e5d626335120dd73afe7a1bf0af62",
+    )
+    version(
+        "1.4.1",
+        sha256="3587fe257d8dcb6aa16a90ea6ab23a62b0894671fa91531a084611006719b234",
+    )
+    version(
+        "1.4.0",
+        sha256="714d5556499bbc067682970168fdd5e7a1b9ea3895f8153451032c5933747019",
+    )
+    version(
+        "1.3.2",
+        sha256="3abf080f8eb416ca6963ef9a1c5a039727119eea80d4eed2cceb8af3446bf9a2",
+    )
+    version(
+        "1.3.1",
+        sha256="e2acf781f34990f3602a078a65127b846f90a54dfbdbbdb63349931ed19e161e",
+    )
+    version(
+        "1.3.0",
+        sha256="b000c9f1f482b82c6a8b8f9daa5e7d4ce8c350fe09380f708d4c4077e22442bb",
+    )
+    version(
+        "1.2.1",
+        sha256="6a3ef0115a40369fc70c11218bccc957196730554f7ccf59da70e3dcdb12dcb9",
+    )
+    version(
+        "1.2.0",
+        sha256="89b1226248bca10ecb1677e065ffceae71921be0685988d66a0b7a0a13dbbbb3",
+    )
+    version(
+        "1.1.1",
+        sha256="05b7488481a6614b3a933786badd7b8f5eba97023047e35f63098ace427f5219",
+    )
+    version(
+        "1.1.0",
+        sha256="16bae53095bdf485824a6ff4b186b3f4435a21efd6ee3342604c0515cbf3ed4f",
+    )
+    version(
         "1.0.0",
         sha256="f7616b39150378ad8697e1b797edddce2f91181d1105b00b1dd66d618100c632",
     )

--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -14,14 +14,46 @@ class EpicEic(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
-    version("23.07.2", sha256="e80c31a338e41766aecc76441ac7aed7d53ddf401c7ca8773b0124536096ef2d")
-    version("23.07.1", sha256="7e5908b3a64941ca2ff81195d62b3da6c8a20c4431f903a3c1bdda30bd39fac3")
-    version("23.07.0", sha256="3b2fd83ee1664cb6bb47e45098c0357649d33526bac1e8637118bec4cd88295e")
-    version("23.06.1", sha256="c78a756f84f34c6bb7b39e2bb104ffa7bcb2c7d0dcbdaa7905fe44f81e7b17aa")
-    version("23.06.0", sha256="3e9825457920b97cab1bc73f44b8cfc45130f66a5d00c4acde4f8b9079a661b1")
-    version("23.05.2", sha256="afb31d076a7859bd4cd94d9eed237f402a5cc56100c53c933ed4a024c8ef997b")
-    version("23.05.1", sha256="4cac31b2619b3aafaaa9cc6a43923a97d04d74b753eb580990d569d1ef94c94d")
-    version("23.05.0", sha256="a72774ffc3176178b128a4069d2a7bebfebde91192d971d0ccd3ab3392ff7977")
+    version(
+        "23.09.0",
+        sha256="6f2ced07ead619ad4096246966383f7362d34fb140f8c0f3f60e775401deb303",
+    )
+    version(
+        "23.08.0",
+        sha256="1a8f82ef75d19dfad7228fcb437736622fc984caf0cf06466209124a8559d968",
+    )
+    version(
+        "23.07.2",
+        sha256="e80c31a338e41766aecc76441ac7aed7d53ddf401c7ca8773b0124536096ef2d",
+    )
+    version(
+        "23.07.1",
+        sha256="7e5908b3a64941ca2ff81195d62b3da6c8a20c4431f903a3c1bdda30bd39fac3",
+    )
+    version(
+        "23.07.0",
+        sha256="3b2fd83ee1664cb6bb47e45098c0357649d33526bac1e8637118bec4cd88295e",
+    )
+    version(
+        "23.06.1",
+        sha256="c78a756f84f34c6bb7b39e2bb104ffa7bcb2c7d0dcbdaa7905fe44f81e7b17aa",
+    )
+    version(
+        "23.06.0",
+        sha256="3e9825457920b97cab1bc73f44b8cfc45130f66a5d00c4acde4f8b9079a661b1",
+    )
+    version(
+        "23.05.2",
+        sha256="afb31d076a7859bd4cd94d9eed237f402a5cc56100c53c933ed4a024c8ef997b",
+    )
+    version(
+        "23.05.1",
+        sha256="4cac31b2619b3aafaaa9cc6a43923a97d04d74b753eb580990d569d1ef94c94d",
+    )
+    version(
+        "23.05.0",
+        sha256="a72774ffc3176178b128a4069d2a7bebfebde91192d971d0ccd3ab3392ff7977",
+    )
     version(
         "23.03.0",
         sha256="16badb2418531250a81931f920e145c4be9ef93411f091d93202c23e36e91129",
@@ -71,7 +103,7 @@ class EpicEic(CMakePackage):
     depends_on("dd4hep@1.21: +ddrec", when="@23.05.0:")
 
     depends_on("acts-dd4hep", when="@:23.01.0")
-    
+
     depends_on("fmt +shared")
     depends_on("py-pyyaml")
     depends_on("py-jinja2")

--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -86,6 +86,12 @@ class Jana2(CMakePackage, CudaPackage):
 
     conflicts("+cuda", when="@:2.0", msg="CUDA support only available in 2.1 and later")
 
+    # JResourcePool.h: alignas (https://github.com/JeffersonLab/JANA2/pull/239)
+    patch(
+        "https://github.com/JeffersonLab/JANA2/pull/239.patch?full_index=1",
+        sha256="a32220ba30f18f30c196a604c9ccf9ed01676a81aadfad0028214b42a4363e25",
+        when="@2.0.6:2.1.1",
+    )
     # JBacktrace.h: free after use (https://github.com/JeffersonLab/JANA2/pull/224)
     patch(
         "https://github.com/JeffersonLab/JANA2/pull/224.patch?full_index=1",

--- a/packages/npsim/package.py
+++ b/packages/npsim/package.py
@@ -18,6 +18,10 @@ class Npsim(CMakePackage):
 
     version("main", branch="main")
     version(
+        "1.3.0",
+        sha256="6870ca80c6255d1a35b0d05c70e86c7f252e8401dfb53759cbec8a93c5d74794",
+    )
+    version(
         "1.2.0",
         sha256="2a7e039dfcf8ed4c8a22fc9cb00bf73859537b3ee83a5bb128cc1ef451763865",
     )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New versions of eicrecon, epic-eic, edm4eic, npsim, and a patch for jana2.
