### PR TITLE
dd4hep: patch pr1161 (hexagonal segmentation)

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -22,7 +22,7 @@ class Dd4hep(BuiltinDd4hep):
     )
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1161.patch?full_index=1",
-        sha256="",
+        sha256="a75d89c86ab44ef1f3f86201e083c85e4e8f0b3120785d5a76fdc81256a937ac",
         when="@=1.26",
     )
     patch(

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -22,7 +22,7 @@ class Dd4hep(BuiltinDd4hep):
     )
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1161.diff?full_index=1",
-        sha256="2f301aa18033bfbf53c4377e848764a5d6b9a96799e3e990cd17a2648883e141",
+        sha256="4139360e84eb220f2067b85f2dc477b4cd179fb98d7e117a98f43b1fa0baa395",
         when="@=1.26",
     )
     patch(

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -21,7 +21,7 @@ class Dd4hep(BuiltinDd4hep):
         when="@=1.26",
     )
     patch(
-        "https://github.com/AIDASoft/DD4hep/pull/1161.patch?full_index=1",
+        "https://github.com/AIDASoft/DD4hep/pull/1161.diff?full_index=1",
         sha256="2f301aa18033bfbf53c4377e848764a5d6b9a96799e3e990cd17a2648883e141",
         when="@=1.26",
     )

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -22,7 +22,7 @@ class Dd4hep(BuiltinDd4hep):
     )
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1161.patch?full_index=1",
-        sha256="a75d89c86ab44ef1f3f86201e083c85e4e8f0b3120785d5a76fdc81256a937ac",
+        sha256="2f301aa18033bfbf53c4377e848764a5d6b9a96799e3e990cd17a2648883e141",
         when="@=1.26",
     )
     patch(

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -21,6 +21,11 @@ class Dd4hep(BuiltinDd4hep):
         when="@=1.26",
     )
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1161.patch?full_index=1",
+        sha256="",
+        when="@=1.26",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1086.patch?full_index=1",
         sha256="6b049415e2c6989f3927ff2c56e4764de1650cad6ed301d8ac0f047f4e0039c5",
         when="@1.24:1.25.1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This backports support for https://github.com/AIDASoft/DD4hep/pull/1161.