### PR TITLE
Backport dd4hep-pr1170

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -29,6 +29,11 @@ class Dd4hep(BuiltinDd4hep):
         when="@=1.26",
     )
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1170.diff?full_index=1",
+        sha256="dc6985f7f92cb2292b18cb5b7059226c475d3c930f834c40b49e415bbd7a2946",
+        when="@=1.26",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1086.patch?full_index=1",
         sha256="6b049415e2c6989f3927ff2c56e4764de1650cad6ed301d8ac0f047f4e0039c5",
         when="@1.24:1.25.1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Backport https://github.com/AIDASoft/DD4hep/pull/1170 into 1.26.
