### PR TITLE
chore: upgrades for 23.10

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -18,6 +18,10 @@ class Eicrecon(CMakePackage):
 
     version("main", branch="main")
     version(
+        "1.6.0",
+        sha256="f099e4ad400b617f597ca7e1869b9fc5fb2ec6ab13af7dd66972b16ae194106d",
+    )
+    version(
         "1.5.1",
         sha256="3e77b6fc5dfa269f782bb8b3e33112f3cb7c7be9459a8efa6996c189463fad6e",
     )

--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -15,6 +15,14 @@ class EpicEic(CMakePackage):
 
     version("main", branch="main")
     version(
+        "23.10.0",
+        sha256="abf833eea328afb749c1eabbc83072c1382f02fc547ce7e9291e0616db552a0e",
+    )
+    version(
+        "23.09.1",
+        sha256="1fc30d36461e5acc3a54f475e9c01132aca12e74cc2fbec78fb3073fa83782b5",
+    )
+    version(
         "23.09.0",
         sha256="6f2ced07ead619ad4096246966383f7362d34fb140f8c0f3f60e775401deb303",
     )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- eicrecon v1.6.0
- epic-eic 23.09.1, 23.10.0
