### PR TITLE
eicrecon: depends_on cppgsl when @1.6:

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -212,6 +212,7 @@ class Eicrecon(CMakePackage):
     depends_on("irt", when="@0.2.8:")
     depends_on("spdlog")
     depends_on("catch2", when="@1.0.0:")
+    depends_on("cppgsl", when="@1.6:")  # FIXME: when 1.7 is released, this should be changed
 
     def setup_run_environment(self, env):
         env.prepend_path(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of the eicrecon release 1.7 (current main), eicrecon depends on cppgsl.
