### PR TITLE
eicrecon: new version 1.6.1

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -24,6 +24,10 @@ class Eicrecon(CMakePackage):
         sha256="725d53bc4527486fd15d600b1bd329228502ef83c0ff118cc4600eac7cc2d148",
     )
     version(
+        "1.6.1",
+        sha256="fb3cffe9882d912288d40fcb0dc08a24bbe8adf57a53f05a7ab3559baa4c30cb",
+    )
+    version(
         "1.6.0",
         sha256="f099e4ad400b617f597ca7e1869b9fc5fb2ec6ab13af7dd66972b16ae194106d",
     )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
"New" version (1.6.2 is already in).

