### PR TITLE
py-epic-capybara: depends_on py-scipy

### DIFF
--- a/packages/py-epic-capybara/package.py
+++ b/packages/py-epic-capybara/package.py
@@ -28,4 +28,5 @@ class PyEpicCapybara(PythonPackage):
     depends_on("py-hist", type=("build", "run"))
     depends_on("py-pygithub", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
     depends_on("py-uproot", type=("build", "run"))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
epic-capybara now depends on scipy.

