### PR TITLE
epic-eic: new version 23.12.0; eicrecon: new version 1.9.0

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -19,6 +19,7 @@ class Eicrecon(CMakePackage):
     maintainers = ["wdconinc"]
 
     version("main", branch="main")
+    version("1.9.0", sha256="58c32f6953940277c4c01b563cac878b0aae01b09b88e7960d8500aa6080f745")
     version("1.8.1", sha256="7bc073d87fa6b619330bb3c1ce751e0535d04f9db3d04f13108b147759a29d6d")
     version("1.8.0", sha256="f0769d816e4119322e5429db9b9262ecb3cf8b140fa9f07707a6cdf5c77d0832")
     version("1.7.0", sha256="60732169f76d215ad111a9b34affb64b0f1adafa4aba372b53acb39fe50c6b07")

--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -14,6 +14,7 @@ class EpicEic(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
+    version("23.12.0", sha256="04e94abf111d2746315dfa912f86c81c0f11011dff2a65434e00c87ba2de7b4a")
     version("23.11.0", sha256="24d856f718369d4336c56e191b5cb305bae60bcb06d00485154f5145d9acf597")
     version(
         "23.10.0",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated version, in preparation for the 23.12.0 release.