### PR TITLE
juggler: depends_on k4fwcore, k4actstracking

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -175,6 +175,10 @@ class Juggler(CMakePackage):
 
     depends_on("cppgsl")
 
+    # FIXME update to start at 13: when released
+    depends_on("k4fwcore", when="@12:")
+    depends_on("k4actstracking", when="@12:")
+
     def cmake_args(self):
         args = []
         # C++ Standard


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Juggler now depends_on k4fwcore, k4actstracking.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, now requires `key4hep-spack` as repository.

### Does this PR change default behavior?
No.