### PR TITLE
juggler: depends_on algorithms

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -175,6 +175,8 @@ class Juggler(CMakePackage):
 
     depends_on("cppgsl")
 
+    depends_on("algorithms", when="@9.1:")
+
     depends_on("k4fwcore", when="@13:")
     depends_on("k4actstracking", when="@13:")
 
@@ -184,4 +186,8 @@ class Juggler(CMakePackage):
         args.append(
             self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value)
         )
+        if self.spec.satisfies("^algorithms"):
+            args.append(
+                self.define("USE_SYSTEM_ALGORITHMS", True)
+            )
         return args

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -175,7 +175,8 @@ class Juggler(CMakePackage):
 
     depends_on("cppgsl")
 
-    depends_on("algorithms", when="@9.1:")
+    # FIXME change to @14: when released
+    depends_on("algorithms", when="@13:")
 
     depends_on("k4fwcore", when="@13:")
     depends_on("k4actstracking", when="@13:")
@@ -186,8 +187,4 @@ class Juggler(CMakePackage):
         args.append(
             self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value)
         )
-        if self.spec.satisfies("^algorithms"):
-            args.append(
-                self.define("USE_SYSTEM_ALGORITHMS", True)
-            )
         return args


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of juggler-9.1, juggler depends on algorithms as an external package, however that doesn't work with the algorithms CMake targets as defined, and it must use the vendored version.

As of juggler-14, juggler *requires* an external algorithms install.