### PR TITLE
eicrecon: depends_on py-onnxruntime when @1.12:

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -235,7 +235,7 @@ class Eicrecon(CMakePackage):
     depends_on("catch2", when="@1.0.0:")
     depends_on("cppgsl", when="@1.7:")
     depends_on("algorithms", when="@1.7:")
-    depends_on("py-onnxruntime", when="@1.12:")
+    depends_on("py-onnxruntime", when="@1.11:") # FIXME change to 1.12 when released
 
     def setup_run_environment(self, env):
         env.prepend_path(

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -235,6 +235,7 @@ class Eicrecon(CMakePackage):
     depends_on("catch2", when="@1.0.0:")
     depends_on("cppgsl", when="@1.7:")
     depends_on("algorithms", when="@1.7:")
+    depends_on("py-onnxruntime", when="@1.12:")
 
     def setup_run_environment(self, env):
         env.prepend_path(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds the new onnxruntime dependency in eicrecon. No 1.12 released yet, but applies to main.