### PR TITLE
epic-eic: new variant artifacts (default none)

### DIFF
--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -163,6 +163,8 @@ class EpicEic(CMakePackage):
             detector_path = join_path(self.prefix.share, "epic")
             with working_dir(detector_path):
                 os.environ["LD_LIBRARY_PATH"] += os.pathsep + self.prefix.lib
+                if spec.satisfies("@:24.03"):  # no rpath linking until 24.04
+                    os.environ["LD_LIBRARY_PATH"] += os.pathsep + self.spec["root"].prefix.lib.root
                 os.environ["DETECTOR_PATH"] = detector_path
                 checkGeometry = Executable(join_path(spec['dd4hep'].prefix.bin, 'checkGeometry'))
                 checkGeometry('-c', join_path(detector_path, spec.variants["artifacts"].value + ".xml"))

--- a/packages/epic-eic/package.py
+++ b/packages/epic-eic/package.py
@@ -165,6 +165,7 @@ class EpicEic(CMakePackage):
                 os.environ["LD_LIBRARY_PATH"] += os.pathsep + self.prefix.lib
                 if spec.satisfies("@:24.03"):  # no rpath linking until 24.04
                     os.environ["LD_LIBRARY_PATH"] += os.pathsep + self.spec["root"].prefix.lib.root
+                    os.environ["LD_LIBRARY_PATH"] += os.pathsep + self.spec["fmt"].prefix.lib
                 os.environ["DETECTOR_PATH"] = detector_path
                 checkGeometry = Executable(join_path(spec['dd4hep'].prefix.bin, 'checkGeometry'))
                 checkGeometry('-c', join_path(detector_path, spec.variants["artifacts"].value + ".xml"))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a new variant `artifacts` to epic-eic, to optionally install artifacts for a particular configuration. E.g. `epic-eic artifacts=epic_craterlake`

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.