### PR TITLE
edm4eic: add 6.0.1

### DIFF
--- a/packages/edm4eic/package.py
+++ b/packages/edm4eic/package.py
@@ -14,6 +14,7 @@ class Edm4eic(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
+    version("6.0.1", sha256="5c159c61a284c6ad3bcba65532b21ed11fddc194129e84347d30c519d1ef8c77")
     version("6.0.0", sha256="9215b1477ddaaeff5bd0f9ff0990a4b54dc4780fb6c6ab36f0bd9bcc83e59928")
     version(
         "5.0.0",


### PR DESCRIPTION
This is a minor bugfix to correctly set schema_version (goes into ROOT classdef)