### PR TITLE
epic: don't set JUGGLER_* and DETECTOR_VERSION variables

### DIFF
--- a/packages/epic/package.py
+++ b/packages/epic/package.py
@@ -173,11 +173,6 @@ class Epic(CMakePackage):
 
     def setup_run_environment(self, env):
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-        env.set("JUGGLER_DETECTOR_PATH", join_path(self.prefix.share, "epic"))
-        env.set("JUGGLER_DETECTOR", "epic")
-        env.set("JUGGLER_DETECTOR_CONFIG", "epic")
-        env.set("JUGGLER_DETECTOR_VERSION", str(self.spec.version))
         env.set("DETECTOR_PATH", join_path(self.prefix.share, "epic"))
         env.set("DETECTOR", "epic")
         env.set("DETECTOR_CONFIG", "epic")
-        env.set("DETECTOR_VERSION", str(self.spec.version))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the JUGGLER_* and DETECTOR_VERSION variables from the epic package run environment.