### PR TITLE
eicrecon: provide version

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -239,8 +239,11 @@ class Eicrecon(CMakePackage):
     depends_on("catch2", when="@1.0.0:")
     depends_on("cppgsl", when="@1.7:")
     depends_on("algorithms", when="@1.7:")
-    depends_on("py-onnxruntime", when="@1.12:") # FIXME change to 1.13 when released
+    depends_on("py-onnxruntime", when="@1.13:")
 
+    def cmake_flags(self):
+        return [f"-DVERSION={self.version}"]
+    
     def setup_run_environment(self, env):
         env.prepend_path(
             "JANA_PLUGIN_PATH", join_path(self.prefix, "lib", "EICrecon", "plugins")


### PR DESCRIPTION
This should fix `eicrecon --version`

https://github.com/eic/EICrecon/blob/main/cmake/git_version.cmake