### PR TITLE
juggler: new version 14.0.2

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -168,6 +168,7 @@ class Juggler(CMakePackage):
     depends_on("acts@8", when="@3")
 
     depends_on("podio@0.11.0:")
+    conflicts("podio@0.99:", when="@:14.0.1")
 
     depends_on("edm4hep")
 

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -17,6 +17,7 @@ class Juggler(CMakePackage):
 
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
+    version("14.0.2", sha256="78825e34a2db2f99360c1c57a3e24d1fcad2c22b7b17e703c8b693944ebca5e2")
     version("14.0.1", sha256="55efe028ea9c70c2fbb4a33d83126f11f75b04396987c2e55a2b2fd055ca34c8")
     version("14.0.0", sha256="b5a6ec1960868464de530c3d508bee5378a2bfe23ef3afa0d38ad66ddf2bc977")
     version("13.0.0", sha256="5c967e5979b540ccdc64f94f371b9bb9056ff470c3691e8bda0f12b74702feb2")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Juggler-14.0.2 avoids immutable podio collection exceptions.