### PR TITLE
dd4hep: patch 1.29 for PR 1283

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -6,6 +6,11 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1283.diff?full_index=1",
+        sha256="40124c528c68b4056d3c5af536683ed9f2f9e9bfa750d41e50471895aa58fc4b",
+        when="@=1.28",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1190.diff?full_index=1",
         sha256="d6273e4f0367f72b9572b337338d1269a154b948b72f31ff69ad62f850e0d4ac",
         when="@=1.27",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This patches dd4hep 1.29 for https://github.com/AIDASoft/DD4hep/pull/1283.