### PR TITLE
acts: add podio schema_version bugfix

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -24,7 +24,7 @@ class Acts(BuiltinActs):
     patch(
         "https://github.com/acts-project/acts/pull/3132.patch?full_index=1",
         sha256="e0c97940abc2b4eab50834f76dcfcf2e651b7bf961ad3dd6e124a56d4d5e1779",
-        when="@30.3.0:34",
+        when="@30.3.0:34:0",
     )
     patch(
         "https://github.com/acts-project/acts/commit/3255dfc3dddf9c7a82aaddb041d4a6f095d19124.patch?full_index=1",

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -22,6 +22,11 @@ class Acts(BuiltinActs):
 
     # CMakeLists.txt: fix ACTS_USE_SYSTEM_ACTSVG typo
     patch(
+        "https://github.com/acts-project/acts/pull/3132.patch?full_index=1",
+        sha256="e0c97940abc2b4eab50834f76dcfcf2e651b7bf961ad3dd6e124a56d4d5e1779",
+        when="@30.3.0:34",
+    )
+    patch(
         "https://github.com/acts-project/acts/commit/3255dfc3dddf9c7a82aaddb041d4a6f095d19124.patch?full_index=1",
         sha256="60317f6a09a7d57721c1234fcf087ae85aeab27653976d1d3ac7a846c3b85a89",
         when="@20.1.0:26",
@@ -34,7 +39,8 @@ class Acts(BuiltinActs):
 
     def cmake_args(self):
         args = super().cmake_args()
-        args.append(self.define("Python_EXECUTABLE", self.spec["python"].command.path))
+        if self.spec.satisfied("^python"):
+            args.append(self.define("Python_EXECUTABLE", self.spec["python"].command.path))
         return args
 
 

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -24,7 +24,7 @@ class Acts(BuiltinActs):
     patch(
         "https://github.com/acts-project/acts/pull/3132.patch?full_index=1",
         sha256="e0c97940abc2b4eab50834f76dcfcf2e651b7bf961ad3dd6e124a56d4d5e1779",
-        when="@30.3.0:34:0",
+        when="@30.3.0:34.0",
     )
     patch(
         "https://github.com/acts-project/acts/commit/3255dfc3dddf9c7a82aaddb041d4a6f095d19124.patch?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of podio some version or other, we must provide a schema version. This PR backports the schema version to older Acts versions.