### PR TITLE
eicrecon: do not require acts +identification, but require +json

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -229,7 +229,8 @@ class Eicrecon(CMakePackage):
     depends_on("edm4hep")
     depends_on("podio")
 
-    depends_on("acts +dd4hep +identification +tgeo")
+    depends_on("acts +dd4hep +identification +tgeo", when="@:1.15")
+    depends_on("acts +dd4hep +json", when="@1.16:")
     depends_on("acts@30:", when="@1.8:")
     depends_on("acts@:30", when="@:1.9.0")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of Acts-35 there is no more `identification` variant. We don't need it (but CMake-require it for EICrecon versions up to 1.15). After 1.15, we should get rid of it in the CMake requirements and not require it in eic-spack either.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
