### PR TITLE
geant4: add v11.2.2.east

### DIFF
--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -4,13 +4,14 @@ from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 class Geant4(BuiltinGeant4):
     ## Versions with the eAST physics list
+    version("11.2.2.east", git="https://github.com/eic/geant4", branch="east-v11.2.2")
     version("11.2.1.east", git="https://github.com/eic/geant4", branch="east-v11.2.1")
     version("11.2.0.east", git="https://github.com/eic/geant4", branch="east-v11.2.0")
     version("11.1.3.east", git="https://github.com/eic/geant4", branch="east-v11.1.3")
     version("11.1.2.east", git="https://github.com/eic/geant4", branch="east-v11.1.2")
     version("11.1.1.east", git="https://github.com/eic/geant4", branch="east-v11.1.1")
 
-    patch("G4LogicalSkinSurface.patch", when="@11.2")
+    patch("G4LogicalSkinSurface.patch", when="@11.2:11.2.1")
 
     ## Fix commands in /particle/property/decay/
     patch("https://github.com/Geant4/geant4/commit/e32bc92498d87fb42829b08348d7fad89bc89404.diff?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds geant4 v11.2.2.east, which is geant4 with the eAST physics list backported into it. The skin surface patch fix was merged into v11.2.2, so does not need to apply anymore.
