### PR TITLE
milou: fix invalid escape sequence '\$'

### DIFF
--- a/packages/milou/package.py
+++ b/packages/milou/package.py
@@ -30,7 +30,7 @@ class Milou(MakefilePackage):
         # ./Makefile
         makefile = FileFilter("Makefile")
         makefile.filter("BITS = 32", "#BITS = 32")
-        makefile.filter("-m\$\(BITS\) ", "")
+        makefile.filter(r"-m\$\(BITS\) ", "")
         makefile.filter(
             "CERN_LIBS = .*", "CERN_LIBS = {0}/lib".format(spec["cernlib"].prefix)
         )
@@ -42,7 +42,7 @@ class Milou(MakefilePackage):
         # ./bases51/Makefile
         makefile = FileFilter("bases51/Makefile")
         makefile.filter("BITS = 32", "#BITS = 32")
-        makefile.filter("-m\$\(BITS\) ", "")
+        makefile.filter(r"-m\$\(BITS\) ", "")
         if spec.satisfies("%gcc@10:"):
             makefile.filter("F_FLAGS = -g", "F_FLAGS = -g -fallow-argument-mismatch")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the following python warning:
```
$ spack info milou
==> Warning: invalid escape sequence '\$'
==> Warning: invalid escape sequence '\$'
MakefilePackage:   milou

Description:
    MILOU is a Monte Carlo generator for deeply virtual Compton scattering
    (DVCS).

```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.