### PR TITLE
escalate: g4e has on compat variant, now uses validated

### DIFF
--- a/packages/escalate/package.py
+++ b/packages/escalate/package.py
@@ -109,5 +109,5 @@ class Escalate(BundlePackage):
     # depends_on('ejpm@0.3.12', when='@1.0.1')  # FIXME no package
     depends_on("eic-smear@1.0.4-fix1 +pythia6", when="@1.0.1")
     depends_on("ejana@1.2.2 +acts +genfit", when="@1.0.1")
-    depends_on("g4e@1.3.4 +compat", when="@1.0.1")
+    depends_on("g4e@1.3.4 ~validated", when="@1.0.1")
     depends_on("jana2@2.0.2 +root", when="@1.0.1")

--- a/packages/escalate/package.py
+++ b/packages/escalate/package.py
@@ -77,7 +77,7 @@ class Escalate(BundlePackage):
     # depends_on('ejpm@0.3.21', when='@1.1.0')  # FIXME no package
     depends_on("eic-smear@1.0.4-fix1 +pythia6", when="@1.1.0")
     depends_on("ejana@1.2.3 +acts +genfit", when="@1.1.0")
-    depends_on("g4e@1.3.5 +compat", when="@1.1.0")
+    depends_on("g4e@1.3.5 ~validated", when="@1.1.0")
     depends_on("jana2@2.0.3 +root", when="@1.1.0")
 
     version("1.0.1")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since https://github.com/eic/eic-spack/commit/e540ec206b8c17aac41852b692b3a2e426f7bf6c, `g4e` has no more `compat` variant. It was renamed to `validated` and the logic inverted. This PR adapts `escalate` to the new way.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.