### PR TITLE
acts: remove podio@:0 version limit in upstream spack

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -16,7 +16,7 @@ class Acts(BuiltinActs):
         when="@20.1.0:26",
     )
 
-    @when("@34:35")
+    @when("@33:35")
     def patch(self):
         # HACK Remove upstream limitations on podio@:0
         filter_file("_acts_podio_version 0.16", "_acts_podio_version 1.0", "CMakeLists.txt")

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -3,12 +3,28 @@ from spack.pkg.builtin.acts import Acts as BuiltinActs
 
 
 class Acts(BuiltinActs):
+    def __init__(self, spec):
+        super(Acts, self).__init__(spec)
+        # HACK Remove upstream limitations on podio@:0
+        for _spec in ["@:35+edm4hep", "@:35+podio"]:
+            if spack.spec.Spec(_spec) in Acts.dependencies:
+                del Acts.dependencies[spack.spec.Spec(_spec)]
+
     patch(
         "https://github.com/acts-project/acts/commit/3255dfc3dddf9c7a82aaddb041d4a6f095d19124.patch?full_index=1",
         sha256="60317f6a09a7d57721c1234fcf087ae85aeab27653976d1d3ac7a846c3b85a89",
         when="@20.1.0:26",
     )
+
+    @when("@34:35")
+    def patch(self):
+        super().patch()
+        # HACK Remove upstream limitations on podio@:0
+        filter_file("_acts_podio_version 0.16", "_acts_podio_version 1.0", "CMakeLists.txt")
+
     def cmake_args(self):
         args = super().cmake_args()
         args.append(self.define("Python_EXECUTABLE", self.spec["python"].command.path))
         return args
+
+_acts = Acts("acts")

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -10,6 +10,14 @@ class Acts(BuiltinActs):
             if spack.spec.Spec(_spec) in Acts.dependencies:
                 del Acts.dependencies[spack.spec.Spec(_spec)]
 
+    # Plugins/Podio/edm.yml: add schema_version
+    patch(
+        "https://github.com/acts-project/acts/commit/8fce1a7b32aa39f967919adc4cabebbfde2a7a97.patch?full_index=1",
+        sha256="https://github.com/acts-project/acts/commit/8fce1a7b32aa39f967919adc4cabebbfde2a7a97.patch?full_index=1",
+        when="@30.3.0:34.0",
+    )
+
+    # CMakeLists.txt: fix ACTS_USE_SYSTEM_ACTSVG typo
     patch(
         "https://github.com/acts-project/acts/commit/3255dfc3dddf9c7a82aaddb041d4a6f095d19124.patch?full_index=1",
         sha256="60317f6a09a7d57721c1234fcf087ae85aeab27653976d1d3ac7a846c3b85a89",

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -18,7 +18,6 @@ class Acts(BuiltinActs):
 
     @when("@34:35")
     def patch(self):
-        super().patch()
         # HACK Remove upstream limitations on podio@:0
         filter_file("_acts_podio_version 0.16", "_acts_podio_version 1.0", "CMakeLists.txt")
 

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -13,7 +13,7 @@ class Acts(BuiltinActs):
     # Plugins/Podio/edm.yml: add schema_version
     patch(
         "https://github.com/acts-project/acts/commit/8fce1a7b32aa39f967919adc4cabebbfde2a7a97.patch?full_index=1",
-        sha256="https://github.com/acts-project/acts/commit/8fce1a7b32aa39f967919adc4cabebbfde2a7a97.patch?full_index=1",
+        sha256="78d4fac4235f7659c674a267f11e2d5bcad82af0d9df2036ef620d64997497d0",
         when="@30.3.0:34.0",
     )
 

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -26,4 +26,6 @@ class Acts(BuiltinActs):
         args.append(self.define("Python_EXECUTABLE", self.spec["python"].command.path))
         return args
 
+
+# instantiate at least once
 _acts = Acts("acts")

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -36,4 +36,4 @@ class Acts(BuiltinActs):
 
 
 # instantiate at least once
-_acts = Acts("acts")
+_acts = Acts(spack.spec.Spec("acts"))

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -6,6 +6,6 @@ class K4fwcore(BuiltinK4fwcore):
     # Allow podio@1: in CMakeLists.txt
     patch(
         "https://github.com/key4hep/k4FWCore/commit/d6e72d1fe24fe3e1c28d667a84e9f97e295d8976.patch?full_index=1",
-        sha256sum="55c77a1eb7b57d14e0901f178bdd630311bebdd75eb971d659e37657a90e5738",
+        sha256="55c77a1eb7b57d14e0901f178bdd630311bebdd75eb971d659e37657a90e5738",
         when="@1.0pre17:1.0pre19",
     )

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,0 +1,11 @@
+from spack import *
+from spack.pkg.k4.k4fwcore import K4fwcore as BuiltinK4fwcore
+
+
+class K4fwcore(BuiltinK4fwcore):
+    # Allow podio@1: in CMakeLists.txt
+    patch(
+        "https://github.com/key4hep/k4FWCore/commit/d6e72d1fe24fe3e1c28d667a84e9f97e295d8976.patch?full_index=1",
+        sha256sum="55c77a1eb7b57d14e0901f178bdd630311bebdd75eb971d659e37657a90e5738",
+        when="@1.0pre17:1.0pre19",
+    )

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -3,6 +3,12 @@ from spack.pkg.k4.k4fwcore import K4fwcore as BuiltinK4fwcore
 
 
 class K4fwcore(BuiltinK4fwcore):
+    # Remove rootUtils.h header that has become unnecessary
+    patch(
+        "https://github.com/key4hep/k4FWCore/commit/70c9c113f48d941822066430f48eee8be007f49b.patch?full_index=1",
+        sha256="165e809c24a807d0b3e29b575e913ca09bf79f7f8308de44bf955db7c99fc5b9",
+        when="@1.0pre18:1.0pre19",
+    )
     # Allow podio@1: in CMakeLists.txt
     patch(
         "https://github.com/key4hep/k4FWCore/commit/d6e72d1fe24fe3e1c28d667a84e9f97e295d8976.patch?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The spack `acts` package has a `depends_on("podio@:0")` (with some `when` conditions). If we want to support podio@0 locally, for transient purposes, then we need to remove this upstream dependency. This PR does that through some python hackery.