### PR TITLE
fix(ci): run build_packages against develop

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -28,9 +28,6 @@ jobs:
         id: set-tag
         run: |
           base_ref=${{ github.event.pull_request.base.ref || github.ref }}
-          if [[ $base_ref =~ ^develop$ ]] ; then
-            TAG=latest
-          fi 
           if [[ $base_ref =~ ^releases/(v[0-9].[0-9]+)$ ]] ; then 
             TAG=${BASH_REMATCH[1]}.0
           fi


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the workaround for `develop` branch here. It now will use the `develop` tag for the spack container image too.