### PR TITLE
fix: ensure from spack.package import *

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.acts import Acts as BuiltinActs
 
 

--- a/packages/afterburner/package.py
+++ b/packages/afterburner/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from spack.package import *
 
 
 class Afterburner(CMakePackage):

--- a/packages/athena-eic/package.py
+++ b/packages/athena-eic/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class AthenaEic(CMakePackage):

--- a/packages/bmf/package.py
+++ b/packages/bmf/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Bmf(CMakePackage):

--- a/packages/dawn/package.py
+++ b/packages/dawn/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 import os
 
 

--- a/packages/dawncut/package.py
+++ b/packages/dawncut/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 import os
 
 

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.dd4hep import Dd4hep as BuiltinDd4hep
 
 

--- a/packages/east/package.py
+++ b/packages/east/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class East(CMakePackage):

--- a/packages/edm4eic/package.py
+++ b/packages/edm4eic/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class Edm4eic(CMakePackage):

--- a/packages/eic-ip6/package.py
+++ b/packages/eic-ip6/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class EicIp6(CMakePackage):

--- a/packages/eic-smear/package.py
+++ b/packages/eic-smear/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class EicSmear(CMakePackage):

--- a/packages/eic/package.py
+++ b/packages/eic/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Eic(BundlePackage):

--- a/packages/eicd/package.py
+++ b/packages/eicd/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class Eicd(CMakePackage):

--- a/packages/eicroot/package.py
+++ b/packages/eicroot/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Eicroot(CMakePackage):

--- a/packages/eictoymodel/package.py
+++ b/packages/eictoymodel/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Eictoymodel(CMakePackage):

--- a/packages/ejana/package.py
+++ b/packages/ejana/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Ejana(CMakePackage):

--- a/packages/epic/package.py
+++ b/packages/epic/package.py
@@ -1,5 +1,5 @@
 import os
-from spack import *
+from spack.package import *
 
 
 class Epic(CMakePackage):

--- a/packages/escalate/package.py
+++ b/packages/escalate/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Escalate(BundlePackage):

--- a/packages/estarlight/package.py
+++ b/packages/estarlight/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class Estarlight(CMakePackage):

--- a/packages/farmhash/package.py
+++ b/packages/farmhash/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Farmhash(AutotoolsPackage):

--- a/packages/fluka/package.py
+++ b/packages/fluka/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 import os
 import tarfile
 

--- a/packages/g4e/package.py
+++ b/packages/g4e/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class G4e(CMakePackage):

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.gaudi import Gaudi as BuiltinGaudi
 
 

--- a/packages/geant3-vmc/package.py
+++ b/packages/geant3-vmc/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Geant3Vmc(CMakePackage):

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 

--- a/packages/hepmc3/package.py
+++ b/packages/hepmc3/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.hepmc3 import Hepmc3 as BuiltinHepmc3
 
 

--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Jana2(CMakePackage, CudaPackage):

--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class Juggler(CMakePackage):

--- a/packages/libodbcpp/package.py
+++ b/packages/libodbcpp/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Libodbcpp(AutotoolsPackage):

--- a/packages/milou/package.py
+++ b/packages/milou/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Milou(MakefilePackage):

--- a/packages/nanocernlib/package.py
+++ b/packages/nanocernlib/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Nanocernlib(CMakePackage):

--- a/packages/npdet/package.py
+++ b/packages/npdet/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 
 
 class Npdet(CMakePackage):

--- a/packages/pepsi/package.py
+++ b/packages/pepsi/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Pepsi(MakefilePackage):

--- a/packages/podio/package.py
+++ b/packages/podio/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.podio import Podio as BuiltinPodio
 
 

--- a/packages/py-epic-capybara/package.py
+++ b/packages/py-epic-capybara/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyEpicCapybara(PythonPackage):
     """Scripts for ROOT file comparisons."""

--- a/packages/py-minkowskiengine/package.py
+++ b/packages/py-minkowskiengine/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.py_minkowskiengine import (
     PyMinkowskiengine as BuiltinPyMinkowskiengine,
 )

--- a/packages/py-smear/package.py
+++ b/packages/py-smear/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class PySmear(PythonPackage):

--- a/packages/pythia6m/package.py
+++ b/packages/pythia6m/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Pythia6m(CMakePackage):

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.builtin.root import Root as BuiltinRoot
 
 

--- a/packages/tensorflow-lite/package.py
+++ b/packages/tensorflow-lite/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 import os
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that all packages have a `from spack.package import *` line since it is not injected by spack anymore. Ref: https://github.com/spack/spack/pull/47947

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.
