### PR TITLE
DD4hep: add `CartesianGridUV`  segmentation class, needed for OuterMPGDBarrel.

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -8,7 +8,7 @@ class Dd4hep(BuiltinDd4hep):
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1365.diff?full_index=1",
         sha256="fe28edb4059647e4f18141d08f7ba8470b5e99dc03048d4faf404170285d89fd",
-        when="@=1.29",
+        when="@=1.30",
     )
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1294.diff?full_index=1",

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -6,6 +6,11 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1365.diff?full_index=1",
+        sha256="fe28edb4059647e4f18141d08f7ba8470b5e99dc03048d4faf404170285d89fd",
+        when="@=1.29",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1294.diff?full_index=1",
         sha256="252579cceb1f66edc20e4e14b3390d2b8ec231450aad0f9e1d3c585e34284a1c",
         when="@=1.29",


### PR DESCRIPTION

### Briefly, what does this PR introduce?
OuterMPGDBarel foresees a UV-readout: `CartesianGridUV` provides for implementing it.

### What kind of change does this PR introduce?
- [ ] Other: New feature.

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No change.  Only prepares the ground for a later modification of `epic`.

### Does this PR change default behavior?
No.