### PR TITLE
py-eic-rucio-policy-package: new package

### DIFF
--- a/packages/py-eic-rucio-policy-package/package.py
+++ b/packages/py-eic-rucio-policy-package/package.py
@@ -1,0 +1,26 @@
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyEicRucioPolicyPackage(PythonPackage):
+    """Rucio policy package for the EIC collaborations."""
+
+    homepage = "https://github.com/eic/eic_rucio_policy_package"
+    pypi = "eic_rucio_policy_package/eic_rucio_policy_package-0.0.4.tar.gz"
+    git = "https://github.com/eic/eic_rucio_policy_package.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("0.0.4", sha256="f66b860a45b43ec70b91d369024eea0cb08cd996c3c17da8bb21932d6ee72834")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools@61:", type="build")
+
+    depends_on("py-jsonschema", type=("build", "run"))
+    depends_on("py-rucio-clients", type=("build", "run"))
+    depends_on("py-sqlalchemy", type=("build", "run"))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
New package for py-eic-rucio-policy-package.

```
12:31:15 wdconinc@menelaos ~/git $ spack load py-eic-rucio-policy-package
12:32:15 wdconinc@menelaos ~/git $ python
Python 3.11.9 (main, Nov 27 2024, 02:41:10) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from eic_rucio_policy_package import schema
>>> schema.ACCOUNTS
{'description': 'Array of accounts', 'type': 'array', 'items': {'description': 'Account name', 'type': 'string', 'maxLength': 25, 'pattern': '^[a-zA-Z0-9-_]+$'}, 'minItems': 0, 'maxItems': 1000}
>>> 
12:33:06 wdconinc@menelaos ~/git $ spack edit py-eic-rucio-policy-package
```