### PR TITLE
eicrecon: add variants asan, tsan, ubsan

### DIFF
--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -260,7 +260,7 @@ class Eicrecon(CMakePackage):
 
     def cmake_args(self):
         return [
-            f"-DVERSION={self.version}",
+            self.define("VERSION", self.version),
             self.define_from_variant("USE_ASAN", "asan"),
             self.define_from_variant("USE_TSAN", "tsan"),
             self.define_from_variant("USE_UBSAN", "ubsan"),

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -267,24 +267,6 @@ class Eicrecon(CMakePackage):
             self.define_from_variant("USE_UBSAN", "ubsan"),
         ]
 
-    @when("+asan")
-    @run_after("install")
-    def install_asan_supp(self):
-        mkdirp(self.prefix.share.EICrecon)
-        install(".github/asan.supp", self.prefix.share.EICrecon)
-
-    @when("+lsan")
-    @run_after("install")
-    def install_lsan_supp(self):
-        mkdirp(self.prefix.share.EICrecon)
-        install(".github/lsan.supp", self.prefix.share.EICrecon)
-
-    @when("+ubsan")
-    @run_after("install")
-    def install_ubsan_supp(self):
-        mkdirp(self.prefix.share.EICrecon)
-        install(".github/ubsan.supp", self.prefix.share.EICrecon)
-
     def setup_run_environment(self, env):
         env.prepend_path(
             "JANA_PLUGIN_PATH", join_path(self.prefix, "lib", "EICrecon", "plugins")

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -258,7 +258,7 @@ class Eicrecon(CMakePackage):
     depends_on("algorithms", when="@1.7:")
     depends_on("py-onnxruntime", when="@1.13:")
 
-    def cmake_flags(self):
+    def cmake_args(self):
         return [
             f"-DVERSION={self.version}",
             self.define_from_variant("USE_ASAN", "asan"),

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -230,6 +230,7 @@ class Eicrecon(CMakePackage):
     )
 
     variant("asan", default=False, description="Enable address sanitizer")
+    variant("lsan", default=False, description="Enable leak sanitizer", when="+asan")
     variant("tsan", default=False, description="Enable thread sanitizer")
     variant("ubsan", default=False, description="Enable undefined behavior sanitizer")
 
@@ -272,6 +273,12 @@ class Eicrecon(CMakePackage):
         mkdirp(self.prefix.share.EICrecon)
         install(".github/asan.supp", self.prefix.share.EICrecon)
 
+    @when("+lsan")
+    @run_after("install")
+    def install_lsan_supp(self):
+        mkdirp(self.prefix.share.EICrecon)
+        install(".github/lsan.supp", self.prefix.share.EICrecon)
+
     @when("+ubsan")
     @run_after("install")
     def install_ubsan_supp(self):
@@ -291,6 +298,14 @@ class Eicrecon(CMakePackage):
                     "malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:"
                     "detect_stack_use_after_return=1:detect_odr_violation=1:"
                     "new_delete_type_mismatch=0:intercept_tls_get_addr=0"
+                ),
+            )
+
+        if self.spec.satisfies("+lsan"):
+            env.set(
+                "LSAN_OPTIONS",
+                (
+                    f"suppressions={self.prefix}/share/EICrecon/lsan.supp:"
                 ),
             )
 

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -305,7 +305,7 @@ class Eicrecon(CMakePackage):
             env.set(
                 "LSAN_OPTIONS",
                 (
-                    f"suppressions={self.prefix}/share/EICrecon/lsan.supp:"
+                    f"suppressions={self.prefix}/share/EICrecon/lsan.supp"
                 ),
             )
 

--- a/packages/eicrecon/package.py
+++ b/packages/eicrecon/package.py
@@ -229,6 +229,10 @@ class Eicrecon(CMakePackage):
         sha256="dcc8b60530a627c825413c07472659ba155600339ef8b8e742e3c997bcc504ae",
     )
 
+    variant("asan", default=False, description="Enable address sanitizer")
+    variant("tsan", default=False, description="Enable thread sanitizer")
+    variant("ubsan", default=False, description="Enable undefined behavior sanitizer")
+
     depends_on("cxx", type="build")
     depends_on("cmake@3.16:", type="build")
 
@@ -255,9 +259,47 @@ class Eicrecon(CMakePackage):
     depends_on("py-onnxruntime", when="@1.13:")
 
     def cmake_flags(self):
-        return [f"-DVERSION={self.version}"]
-    
+        return [
+            f"-DVERSION={self.version}",
+            self.define_from_variant("USE_ASAN", "asan"),
+            self.define_from_variant("USE_TSAN", "tsan"),
+            self.define_from_variant("USE_UBSAN", "ubsan"),
+        ]
+
+    @when("+asan")
+    @run_after("install")
+    def install_asan_supp(self):
+        mkdirp(self.prefix.share.EICrecon)
+        install(".github/asan.supp", self.prefix.share.EICrecon)
+
+    @when("+ubsan")
+    @run_after("install")
+    def install_ubsan_supp(self):
+        mkdirp(self.prefix.share.EICrecon)
+        install(".github/ubsan.supp", self.prefix.share.EICrecon)
+
     def setup_run_environment(self, env):
         env.prepend_path(
             "JANA_PLUGIN_PATH", join_path(self.prefix, "lib", "EICrecon", "plugins")
         )
+
+        if self.spec.satisfies("+asan"):
+            env.set(
+                "ASAN_OPTIONS",
+                (
+                    f"suppressions={self.prefix}/share/EICrecon/asan.supp:"
+                    "malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:"
+                    "detect_stack_use_after_return=1:detect_odr_violation=1:"
+                    "new_delete_type_mismatch=0:intercept_tls_get_addr=0"
+                ),
+            )
+
+        if self.spec.satisfies("+ubsan"):
+            env.set(
+                "UBSAN_OPTIONS",
+                (
+                    f"suppressions={self.prefix}/share/EICrecon/ubsan.supp:"
+                    "print_stacktrace=1:silence_unsigned_overflow=1:"
+                    "report_error_type=1"
+                ),
+            )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds variants to support eicrecon sanitizers. It sets the suppressions to what's in .github, and sets options variables to what's currently in the eicrecon CI workflows.
