### PR TITLE
k4actstracking: filter_file when Acts version >= 37

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,4 +1,4 @@
-from spack import *
+from spack.package import *
 from spack.pkg.k4.k4actstracking import K4actstracking as BuiltinK4actstracking
 
 

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,0 +1,12 @@
+from spack import *
+from spack.pkg.k4.k4actstracking import K4actstracking as BuiltinK4actstracking
+
+
+class K4actstracking(BuiltinK4actstracking):
+    def patch(self):
+        filter_file(
+            "m_obj.write(m_outputFileName)",
+            "m_obj.write(m_outputFileName.value())",
+            "k4ActsTracking/src/components/ActsGeoSvc.cpp",
+            string=True,
+        )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Applies https://github.com/key4hep/k4ActsTracking/pull/19 to ensure that we can use Acts-37 and more recent.
