### PR TITLE
geant4: add v11.3.0.east

### DIFF
--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -4,6 +4,7 @@ from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 class Geant4(BuiltinGeant4):
     ## Versions with the eAST physics list
+    version("11.3.0.east", git="https://github.com/eic/geant4", branch="east-v11.3.0")
     version("11.2.2.east", git="https://github.com/eic/geant4", branch="east-v11.2.2")
     version("11.2.1.east", git="https://github.com/eic/geant4", branch="east-v11.2.1")
     version("11.2.0.east", git="https://github.com/eic/geant4", branch="east-v11.2.0")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds the geant4 version with the eAST physics list backported into it.

- [x] #712 