### PR TITLE
fix: keep pkgs at module top level; provide actionable warning

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,16 +1,17 @@
+import llnl.util.tty as tty
 from spack.package import *
 
 try:
     from spack.pkg.k4.k4actstracking import K4actstracking as BuiltinK4actstracking
-
-    class K4actstracking(BuiltinK4actstracking):
-        def patch(self):
-            filter_file(
-                "m_obj.write(m_outputFileName)",
-                "m_obj.write(m_outputFileName.value())",
-                "k4ActsTracking/src/components/ActsGeoSvc.cpp",
-                string=True,
-            )
-
 except:
-    pass
+    tty.warn("k4actstracking requires the key4hep-spack repository")
+    from spack.package import Package as BuiltinK4actstracking
+
+class K4actstracking(BuiltinK4actstracking):
+    def patch(self):
+        filter_file(
+            "m_obj.write(m_outputFileName)",
+            "m_obj.write(m_outputFileName.value())",
+            "k4ActsTracking/src/components/ActsGeoSvc.cpp",
+            string=True,
+        )

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,21 +1,22 @@
-from spack import *
+import llnl.util.tty as tty
+from spack.package import *
 
 try:
     from spack.pkg.k4.k4fwcore import K4fwcore as BuiltinK4fwcore
-
-    class K4fwcore(BuiltinK4fwcore):
-        # Remove rootUtils.h header that has become unnecessary
-        patch(
-            "https://github.com/key4hep/k4FWCore/commit/70c9c113f48d941822066430f48eee8be007f49b.patch?full_index=1",
-            sha256="165e809c24a807d0b3e29b575e913ca09bf79f7f8308de44bf955db7c99fc5b9",
-            when="@1.0pre18:1.0pre19",
-        )
-        # Allow podio@1: in CMakeLists.txt
-        patch(
-            "https://github.com/key4hep/k4FWCore/commit/d6e72d1fe24fe3e1c28d667a84e9f97e295d8976.patch?full_index=1",
-            sha256="55c77a1eb7b57d14e0901f178bdd630311bebdd75eb971d659e37657a90e5738",
-            when="@1.0pre17:1.0pre19",
-        )
-
 except:
-    pass
+    tty.warn("k4fwcore requires the key4hep-spack repository")
+    from spack.package import Package as BuiltinK4fwcore
+
+class K4fwcore(BuiltinK4fwcore):
+    # Remove rootUtils.h header that has become unnecessary
+    patch(
+        "https://github.com/key4hep/k4FWCore/commit/70c9c113f48d941822066430f48eee8be007f49b.patch?full_index=1",
+        sha256="165e809c24a807d0b3e29b575e913ca09bf79f7f8308de44bf955db7c99fc5b9",
+        when="@1.0pre18:1.0pre19",
+    )
+    # Allow podio@1: in CMakeLists.txt
+    patch(
+        "https://github.com/key4hep/k4FWCore/commit/d6e72d1fe24fe3e1c28d667a84e9f97e295d8976.patch?full_index=1",
+        sha256="55c77a1eb7b57d14e0901f178bdd630311bebdd75eb971d659e37657a90e5738",
+        when="@1.0pre17:1.0pre19",
+    )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This is a better fix for k4fwcore and k4actstracking, which warns users and tells them what to do (kinda).
