### PR TITLE
dd4hep: add patch to install plugin headers

### DIFF
--- a/packages/dd4hep/DDCorePlugins-install-headers.patch
+++ b/packages/dd4hep/DDCorePlugins-install-headers.patch
@@ -1,0 +1,15 @@
+diff --git a/DDCore/CMakeLists.txt b/DDCore/CMakeLists.txt
+index 2ba7261a..35379d67 100644
+--- a/DDCore/CMakeLists.txt
++++ b/DDCore/CMakeLists.txt
+@@ -107,6 +107,10 @@ endif()
+ # Generate DDCore plugins---------------------------------------------------------
+ dd4hep_add_plugin(DDCorePlugins SOURCES src/plugins/*.cpp USES DDCore)
+ 
++# Install DDCore plugin headers
++file(GLOB DDCorePlugins_headers src/plugins/*.h)
++install(FILES ${DDCorePlugins_headers} DESTINATION include/DD4hep/plugins)
++
+ # Graphics DDCore plugins---------------------------------------------------------
+ dd4hep_add_plugin(DDCoreGraphics
+   SOURCES src/graphics/*.cpp

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -6,6 +6,10 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "DDCorePlugins-install-headers.patch",
+        when="@1.26:",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1365.diff?full_index=1",
         sha256="fe28edb4059647e4f18141d08f7ba8470b5e99dc03048d4faf404170285d89fd",
         when="@=1.30",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR patches DD4hep to install plugin headers.