### PR TITLE
Update hepmc-merger to version 1.0.5

### DIFF
--- a/packages/hepmcmerger/package.py
+++ b/packages/hepmcmerger/package.py
@@ -20,6 +20,7 @@ class Hepmcmerger(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
+    version("1.0.5", sha256="3660c602212368f04e98a36ced68e4ea3dcc8a23a0cb5047ef27afe07c16bf32")
     version("1.0.4", sha256="0f5e1d6b2d76af764f5cc528ccfad1269047f6e361b6bc0a1b80941388f71437")
     version("1.0.3", sha256="9f245dc46e159f9424383a4337ebbc685973e83240fe178c776e6cca5e9674f0")
     version("1.0.2", sha256="e8bb639545e472f46b7de8f0c6e03c9ee61086c92b8ffcba661f0fe3b1064ad6")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Update hepmc-merger to version 1.0.5. Allows mixing a fourth background source. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
