### PR TITLE
algorithms: add v1.2.0

### DIFF
--- a/packages/algorithms/package.py
+++ b/packages/algorithms/package.py
@@ -17,7 +17,8 @@ class Algorithms(CMakePackage):
 
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
-    version("1.1.0", sha256="f7fef07ee4217b1d224bbe3f87e21e155e1e205356ad5a19b7d09558e7c5c024")  
+    version("1.2.0", sha256="893da7948baf9aa778b1716b3ce7331cd14befa7e43f3cce810c6b49235c73fd")
+    version("1.1.0", sha256="f7fef07ee4217b1d224bbe3f87e21e155e1e205356ad5a19b7d09558e7c5c024", deprecated=True)  # exposes log() function
     version("1.0.0", sha256="b36598ba539938c0f8e5d75170f770e5701a1ad81dbee929ccc36df15233a99d")
 
     depends_on("c", type="build")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds algorithms 1.2.0, which reverts the `report_fmt<lvl>` name change.