### PR TITLE
root: add v6.32.14

### DIFF
--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -3,6 +3,7 @@ from spack.pkg.builtin.root import Root as BuiltinRoot
 
 
 class Root(BuiltinRoot):
+    version("6.32.14", sha256="dfb5193127ff80ebfa10e6a4dcdf56eeec0eface65fc3de347d853ae9653aeff")
     version("6.32.12", sha256="2e41968aeb0406ee31c30af9c046143099b251846e0839cb04f4e960c7893e19")
     version("6.32.10", sha256="5a896804ec153685e8561adaa4e546b708139c484280aa6713a0a178f5b7f98b")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the new `root` version 6.32.14, which is a bugfix release ([release notes](https://root.cern/doc/v632/release-notes.html#release-6.32.14)).