### PR TITLE
py-rpds-py: rm depends_on rust type=run

### DIFF
--- a/packages/py-rpds-py/package.py
+++ b/packages/py-rpds-py/package.py
@@ -1,0 +1,17 @@
+from spack.package import *
+from spack.pkg.builtin.acts import PyRpdsPy as BuiltinPyRpdsPy
+from spack.spec import Spec
+
+
+class PyRpdsPy(BuiltiPyRpdsPy):
+    depends_on("rust@1.76:", type="build", when="@0.19:")
+
+    def __init__(self, spec):
+        super(PyRpdsPy, self).__init__(spec)
+        # HACK Remove rust as a runtime dependency
+        for _spec in ["@0.19:"]:
+            if Spec(_spec) in PyRpdsPy.dependencies:
+                del PyRpdsPy.dependencies[Spec(_spec)]
+
+# instantiate at least once
+_pyrpdspy = PyRpdsPy(Spec("py-rpds-py"))

--- a/packages/py-rpds-py/package.py
+++ b/packages/py-rpds-py/package.py
@@ -1,9 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.acts import PyRpdsPy as BuiltinPyRpdsPy
+from spack.pkg.builtin.py_rpds_py import PyRpdsPy as BuiltinPyRpdsPy
 from spack.spec import Spec
 
 
-class PyRpdsPy(BuiltiPyRpdsPy):
+class PyRpdsPy(BuiltinPyRpdsPy):
     depends_on("rust@1.76:", type="build", when="@0.19:")
 
     def __init__(self, spec):


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the runtime dependency of `py-rpds-py`, and leaves the build-time dependency.