### PR TITLE
dd4hep: add patch for PR#1476

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -8,6 +8,11 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1476.diff?full_index=1",
+        sha256="d72251d248f657e28e3138cf38cf70d865db78611fa5d4826ea399c7ab419a6d",
+        when="@1.31:1.32.1",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1471.diff?full_index=1",
         sha256="6e294a17df753944c2db91729967d82f4f215efa627a50b98c098ac3e2f6e5bc",
         when="@1.31:1.32.1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR backports the patch for https://github.com/AIDASoft/DD4hep/pull/1476.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: geant4 11.3.0 is verbose)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __