### PR TITLE
fix: extend v1 and v2 builtin packages

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -1,7 +1,10 @@
 from spack.package import *
-from spack.pkg.builtin.acts import Acts as BuiltinActs
 from spack.spec import Spec
 
+try:
+    from spack_repo.builtin.packages.acts.package import Acts as BuiltinActs
+except:
+    from spack.pkg.builtin.acts import Acts as BuiltinActs
 
 class Acts(BuiltinActs):
     def __init__(self, spec):

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.dd4hep import Dd4hep as BuiltinDd4hep
 
+try:
+    from spack_repo.builtin.packages.dd4hep.package import Dd4hep as BuiltinDd4hep
+except:
+    from spack.pkg.builtin.dd4hep import Dd4hep as BuiltinDd4hep
 
 class Dd4hep(BuiltinDd4hep):
     version("1.32.1", sha256="f47fbede967b609e142c3116d23b4993f9d57fbae28a1739b5333503bc498883")

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.gaudi import Gaudi as BuiltinGaudi
 
+try:
+    from spack_repo.builtin.packages.gaudi.package import Gaudi as BuiltinGaudi
+except:
+    from spack.pkg.builtin.gaudi import Gaudi as BuiltinGaudi
 
 class Gaudi(BuiltinGaudi):
     patch(

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
+try:
+    from spack_repo.builtin.packages.geant4.package import Geant4 as BuiltinGeant4
+except:
+    from spack.pkg.builtin.geant4 import Geant4 as BuiltinGeant4
 
 class Geant4(BuiltinGeant4):
     ## Versions with the eAST physics list

--- a/packages/hepmc3/package.py
+++ b/packages/hepmc3/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.hepmc3 import Hepmc3 as BuiltinHepmc3
+
+try:
+    from spack_repo.builtin.packages.hepmc3.package import Hepmc3 as BuiltinHepmc3
+except:
+    from spack.pkg.builtin.hepmc3 import Hepmc3 as BuiltinHepmc3
 
 
 class Hepmc3(BuiltinHepmc3):

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,5 +1,9 @@
-import llnl.util.tty as tty
 from spack.package import *
+
+try:
+    import spack.llnl.util.tty as tty
+except:
+    import llnl.util.tty as tty
 
 try:
     from spack.pkg.k4.k4actstracking import K4actstracking as BuiltinK4actstracking

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,5 +1,9 @@
-import llnl.util.tty as tty
 from spack.package import *
+
+try:
+    import spack.llnl.util.tty as tty
+except:
+    import llnl.util.tty as tty
 
 try:
     from spack.pkg.k4.k4fwcore import K4fwcore as BuiltinK4fwcore

--- a/packages/podio/package.py
+++ b/packages/podio/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.podio import Podio as BuiltinPodio
 
+try:
+    from spack_repo.builtin.packages.podio.package import Podio as BuiltinPodio
+except:
+    from spack.pkg.builtin.podio import Podio as BuiltinPodio
 
 class Podio(BuiltinPodio):
     patch(

--- a/packages/py-argcomplete/package.py
+++ b/packages/py-argcomplete/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_argcomplete import PyArgcomplete as BuiltinPyArgcomplete
+
+try:
+    from spack_repo.builtin.packages.py_argcomplete.package import PyArgcomplete as BuiltinPyArgcomplete
+except:
+    from spack.pkg.builtin.py_argcomplete import PyArgcomplete as BuiltinPyArgcomplete
 
 class PyArgcomplete(BuiltinPyArgcomplete):
     version("3.5.3", sha256="c12bf50eded8aebb298c7b7da7a5ff3ee24dffd9f5281867dfe1424b58c55392")

--- a/packages/py-jsonschema/package.py
+++ b/packages/py-jsonschema/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_jsonschema import PyJsonschema as BuiltinPyJsonschema
+
+try:
+     from spack_repo.builtin.packages.py_jsonschema.package import PyJsonschema as BuiltinPyJsonschema
+except:
+     from spack.pkg.builtin.py_jsonschema import PyJsonschema as BuiltinPyJsonschema
 
 class PyJsonschema(BuiltinPyJsonschema):
      version("4.23.0", sha256="d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4")

--- a/packages/py-minkowskiengine/package.py
+++ b/packages/py-minkowskiengine/package.py
@@ -1,8 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_minkowskiengine import (
-    PyMinkowskiengine as BuiltinPyMinkowskiengine,
-)
 
+try:
+    from spack_repo.builtin.packages.py_minkowskiengine.package import PyMinkowskiengine as BuiltinPyMinkowskiengine
+except:
+    from spack.pkg.builtin.py_minkowskiengine import PyMinkowskiengine as BuiltinPyMinkowskiengine
 
 class PyMinkowskiengine(BuiltinPyMinkowskiengine):
     git = "https://github.com/NVIDIA/MinkowskiEngine"

--- a/packages/py-packaging/package.py
+++ b/packages/py-packaging/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_packaging import PyPackaging as BuiltinPyPackaging
+
+try:
+    from spack_repo.builtin.packages.py_packaging.package import PyPackaging as BuiltinPyPackaging
+except:
+    from spack.pkg.builtin.py_packaging import PyPackaging as BuiltinPyPackaging
 
 class PyPackaging(BuiltinPyPackaging):
     version("24.2", sha256="c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f")

--- a/packages/py-python-swiftclient/package.py
+++ b/packages/py-python-swiftclient/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_python_swiftclient import PyPythonSwiftclient as BuiltinPyPythonSwiftclient
+
+try:
+    from spack_repo.builtin.packages.py_python_swiftclient.package import PyPythonSwiftclient as BuiltinPyPythonSwiftclient
+except:
+    from spack.pkg.builtin.py_python_swiftclient import PyPythonSwiftclient as BuiltinPyPythonSwiftclient
 
 class PyPythonSwiftclient(BuiltinPyPythonSwiftclient):
     def url_for_version(self, version):

--- a/packages/py-rich/package.py
+++ b/packages/py-rich/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_rich import PyRich as BuiltinPyRich
+
+try:
+    from spack_repo.builtin.packages.py_rich.package import PyRich as BuiltinPyRich
+except:
+    from spack.pkg.builtin.py_rich import PyRich as BuiltinPyRich
 
 class PyRich(BuiltinPyRich):
     version("13.9.4", sha256="439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098")

--- a/packages/py-rpds-py/package.py
+++ b/packages/py-rpds-py/package.py
@@ -1,7 +1,10 @@
 from spack.package import *
-from spack.pkg.builtin.py_rpds_py import PyRpdsPy as BuiltinPyRpdsPy
 from spack.spec import Spec
 
+try:
+    from spack_repo.builtin.packages.py_rpds_py.package import PyRpdsPy as BuiltinPyRpdsPy
+except ImportError:
+    from spack.pkg.builtin.py_rpds_py import PyRpdsPy as BuiltinPyRpdsPy
 
 class PyRpdsPy(BuiltinPyRpdsPy):
     depends_on("rust@1.76:", type="build", when="@0.19:")

--- a/packages/py-rucio-clients/package.py
+++ b/packages/py-rucio-clients/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_rucio_clients import PyRucioClients as BuiltinPyRucioClients
+
+try:
+    from spack_repo.builtin.packages.py_rucio_clients.package import PyRucioClients as BuiltinPyRucioClients
+except:
+    from spack.pkg.builtin.py_rucio_clients import PyRucioClients as BuiltinPyRucioClients
 
 class PyRucioClients(BuiltinPyRucioClients):
     version(

--- a/packages/py-urllib3/package.py
+++ b/packages/py-urllib3/package.py
@@ -1,5 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.py_urllib3 import PyUrllib3 as BuiltinPyUrllib3
+
+try:
+    from spack_repo.builtin.packages.py_urllib3.package import PyUrllib3 as BuiltinPyUrllib3
+except:
+    from spack.pkg.builtin.py_urllib3 import PyUrllib3 as BuiltinPyUrllib3
 
 class PyUrllib3(BuiltinPyUrllib3):
     version("2.3.0", sha256="f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d")

--- a/packages/pyrobird/package.py
+++ b/packages/pyrobird/package.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
+try:
+    import spack.llnl.util.tty as tty
+except:
+    import llnl.util.tty as tty
 
 class Pyrobird(PythonPackage):
     """Phoenix based event display."""

--- a/packages/rivet/package.py
+++ b/packages/rivet/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.rivet import Rivet as BuiltinRivet
 
+try:
+    from spack_repo.builtin.packages.rivet.package import Rivet as BuiltinRivet
+except:
+    from spack.pkg.builtin.rivet import Rivet as BuiltinRivet
 
 class Rivet(BuiltinRivet):
     with when("@4.1:"):

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -1,6 +1,9 @@
 from spack.package import *
-from spack.pkg.builtin.root import Root as BuiltinRoot
 
+try:
+    from spack_repo.builtin.packages.root.package import Root as BuiltinRoot
+except:
+    from spack.pkg.builtin.root import Root as BuiltinRoot
 
 class Root(BuiltinRoot):
     version("6.32.14", sha256="dfb5193127ff80ebfa10e6a4dcdf56eeec0eface65fc3de347d853ae9653aeff")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adapts the packages here that extend builtin packages to be able to use both v1 and v2 spack package repository namespaces.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: currently not possible to use this repository with current spack-packages repository)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.