### PR TITLE
jana2: depends_on c

### DIFF
--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -83,6 +83,7 @@ class Jana2(CMakePackage, CudaPackage):
     variant("xerces", default=True, description="Build with XML support.")
     variant("zmq", default=False, description="Use zeroMQ for janacontrol.")
 
+    depends_on("c", type="build")  # FIXME https://github.com/JeffersonLab/JANA2/pull/419
     depends_on("cxx", type="build")
     depends_on("cmake@3.16:", type="build")
     depends_on("cppzmq", when="+zmq")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since JANA2 does not explicitly include only `LANGUAGES CXX` in the CMakeLists.txt (see https://github.com/JeffersonLab/JANA2/pull/419), we must ensure a C compiler is available.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/6090505#L3722)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.