### PR TITLE
afterburner: depends_on c when @:0.1.3

### DIFF
--- a/packages/afterburner/package.py
+++ b/packages/afterburner/package.py
@@ -20,7 +20,10 @@ class Afterburner(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
-    version("0.1.3", sha256="765bbe5b9573967e1aeed276d45bd299f3cf52251b6ec9b42fff9e2229fee663")
+    version(
+        "0.1.3",
+        sha256="765bbe5b9573967e1aeed276d45bd299f3cf52251b6ec9b42fff9e2229fee663",
+    )
     version(
         "0.1.2",
         sha256="4de4d8ce9f76830a1e1a2b4b680a78baa5ed2f28f1aaac4c0e861c48bbff259e",
@@ -45,6 +48,7 @@ class Afterburner(CMakePackage):
     variant("root", default=False, description="Support reading ROOT files")
     variant("zlib", default=True, description="Support reading compressed files")
 
+    depends_on("c", type="build", when="@:0.1.3")
     depends_on("cxx", type="build")
 
     depends_on("gsl")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since afterburner did not include the `LANGUAGES CXX` clause in the CMakeLists.txt, we need to provide a C compiler until version 0.1.3. Hopefully this is not needed in the next release. See https://github.com/eic/afterburner/pull/18.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/6090505#L3520)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.