### PR TITLE
hepmcmerger: depends_on c

### DIFF
--- a/packages/hepmcmerger/package.py
+++ b/packages/hepmcmerger/package.py
@@ -30,6 +30,7 @@ class Hepmcmerger(CMakePackage):
     version("1.0.1", sha256="419732c2d46afbad89e32362d339a643dc1e6e5ff9724c3027a45aef1b8fbf95")
     version("1.0.0", sha256="5f36b0b65f1062aab79dc6653b6f6fecb9682022f1a471efa62b5614c9731618")
 
+    depends_on("c", type="build", when="@:2.0.0")
     depends_on("cxx", type="build")
 
     depends_on("hepmc3")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since afterburner did not include the `LANGUAGES CXX` clause in the CMakeLists.txt, we need to provide a C compiler until version 2.0.0. Hopefully this is not needed in the next release. See https://github.com/eic/HEPMC_Merger/pull/17.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/6090505#L3470)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.