### PR TITLE
juggler: depends_on c

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -157,6 +157,7 @@ class Juggler(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("root")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since juggler does not explicitly include only LANGUAGES CXX in the CMakeLists.txt, we must ensure a C compiler is available.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/6095923#L3416)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No 