### PR TITLE
east: depends_on c

### DIFF
--- a/packages/east/package.py
+++ b/packages/east/package.py
@@ -15,6 +15,7 @@ class East(CMakePackage):
 
     version("main", branch="main")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("geant4@10.7.0: +threads")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since `east` does not explicitly include only `LANGUAGES CXX` in the CMakeLists.txt, we must ensure a C compiler is available.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/6099846#L6272)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.