### PR TITLE
acts: variants for dd4hep conversion fixes

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -15,15 +15,17 @@ class Acts(BuiltinActs):
                 del Acts.dependencies[Spec(_spec)]
 
     # Off-axis forward detector fixes
+    variant("pr4502", default=False, description="Acts#4502: propagate transform to ProtoLayer in DD4hep builder")
     patch(
         "https://github.com/acts-project/acts/pull/4502.patch?full_index=1",
         sha256="d9bb4c9748233ac9f9e2bed3fc7d3aec9e5f5181729243be93b9c6eeee7db737",
-        when="@36:42",
+        when="@36:42 +pr4502",
     )
+    variant("pr4496", default=False, description="Acts#4496: enlarge cylinder volume rmax for layers with displaced center")
     patch(
         "https://github.com/acts-project/acts/pull/4496.patch?full_index=1",
         sha256="5aa1fee7437aaac8dc70bbac728c73fa42e59dd2e75ee4d2e7fbde1845889d08",
-        when="@9:42",
+        when="@9:42 +pr4496",
     )
 
     # Core/src/Utilities/AxisDefinitions.cpp: parse correctly


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR makes the DD4hep geometry conversion fixes in Acts optional.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
