### PR TITLE
dd4hep: patch to avoid double deduce/open for HEPMC3FileReader when not ReaderAscii

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -12,7 +12,7 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1495.diff?full_index=1",
-        sha256="471d465f68d3fc79d9f4bcf55edc8518089612624c9aadee67d0937df89dfa68",
+        sha256="e9de70d2c4702147c769da7dc729ec78e0bd0858af9a2d3eb68310667fa21c02",
         when="@:1.32.1",
     )
     patch(

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -11,6 +11,11 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "https://github.com/AIDASoft/DD4hep/pull/1495.diff?full_index=1",
+        sha256="471d465f68d3fc79d9f4bcf55edc8518089612624c9aadee67d0937df89dfa68",
+        when="@:1.32.1",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1476.diff?full_index=1",
         sha256="d72251d248f657e28e3138cf38cf70d865db78611fa5d4826ea399c7ab419a6d",
         when="@1.31:1.32.1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR applies a patch for https://github.com/AIDASoft/DD4hep/pull/1495.
