### PR TITLE
acts: add patch for dd4hep layer builder fix

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -17,8 +17,8 @@ class Acts(BuiltinActs):
     # DD4hep layer builder fix
     variant("pr4620", default=False, description="Acts#4620: ensure DD4hep ProtoLayer understands local coordinate extent")
     patch(
-        "https://github.com/acts-project/acts/pull/4620.diff?full_index=1",
-        sha256="dda4f5ae1749d7692044775fb9fbc5001f31101748938c8bf109939f1ad223f9",
+        "https://github.com/acts-project/acts/compare/main...8ce5520f77fb4420bbeaa9aa9ed941cf1ad26cc9.diff?full_index=1",
+        sha256="8ba58915e294f49aca5d949dbea24ffa745648691e4f80df42dd6c7344acc86a",
         when="@36:42 +pr4620",
     )
     conflicts("+pr4620", when="~pr4502")

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -14,6 +14,14 @@ class Acts(BuiltinActs):
             if Spec(_spec) in Acts.dependencies:
                 del Acts.dependencies[Spec(_spec)]
 
+    # DD4hep layer builder fix
+    variant("pr4620", default=False, description="Acts#4620: ensure DD4hep ProtoLayer understands local coordinate extent")
+    patch(
+        "https://github.com/acts-project/acts/pull/4620.patch?full_index=1",
+        sha256="0146d88459e8ac49cb71faf27e27549523e338320830787c81ef181d682d1c86",
+        when="@36:42 +pr4620",
+    )
+    conflict("+pr4620", when="~pr4502")
     # Off-axis forward detector fixes
     variant("pr4502", default=False, description="Acts#4502: propagate transform to ProtoLayer in DD4hep builder")
     patch(

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -21,7 +21,7 @@ class Acts(BuiltinActs):
         sha256="0146d88459e8ac49cb71faf27e27549523e338320830787c81ef181d682d1c86",
         when="@36:42 +pr4620",
     )
-    conflict("+pr4620", when="~pr4502")
+    conflicts("+pr4620", when="~pr4502")
     # Off-axis forward detector fixes
     variant("pr4502", default=False, description="Acts#4502: propagate transform to ProtoLayer in DD4hep builder")
     patch(

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -17,8 +17,8 @@ class Acts(BuiltinActs):
     # DD4hep layer builder fix
     variant("pr4620", default=False, description="Acts#4620: ensure DD4hep ProtoLayer understands local coordinate extent")
     patch(
-        "https://github.com/acts-project/acts/pull/4620.patch?full_index=1",
-        sha256="0146d88459e8ac49cb71faf27e27549523e338320830787c81ef181d682d1c86",
+        "https://github.com/acts-project/acts/pull/4620.diff?full_index=1",
+        sha256="dda4f5ae1749d7692044775fb9fbc5001f31101748938c8bf109939f1ad223f9",
         when="@36:42 +pr4620",
     )
     conflicts("+pr4620", when="~pr4502")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds https://github.com/acts-project/acts/pull/4620 (as of 8ce5520f77fb4420bbeaa9aa9ed941cf1ad26cc9).