### PR TITLE
acts: update pr4620 patch

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -1,4 +1,4 @@
-from spack.package import *
+classspack.package import *
 from spack.spec import Spec
 
 try:
@@ -17,8 +17,8 @@ class Acts(BuiltinActs):
     # DD4hep layer builder fix
     variant("pr4620", default=False, description="Acts#4620: ensure DD4hep ProtoLayer understands local coordinate extent")
     patch(
-        "https://github.com/acts-project/acts/compare/main...8ce5520f77fb4420bbeaa9aa9ed941cf1ad26cc9.diff?full_index=1",
-        sha256="8ba58915e294f49aca5d949dbea24ffa745648691e4f80df42dd6c7344acc86a",
+        "https://github.com/acts-project/acts/compare/main...a9d1c8c99a3abcd8c697c9e95703352e757f81cf.diff?full_index=1",
+        sha256="ccf241259fb50000aeb0580941880fd35c53e9b45877f9ad675bad25a00caf1d",
         when="@36:42 +pr4620",
     )
     conflicts("+pr4620", when="~pr4502")

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -1,4 +1,4 @@
-classspack.package import *
+from spack.package import *
 from spack.spec import Spec
 
 try:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds https://github.com/acts-project/acts/pull/4620/commits/218590cd20ce3a524d09f7cf355fa883c1e42de6 in order to support layers without sensitive in https://github.com/eic/epic/pull/925.