### PR TITLE
jana2: patch for JFactoryPodioT instantiation error

### DIFF
--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -125,6 +125,13 @@ class Jana2(CMakePackage, CudaPackage):
         when="@2.3.2",
     )
 
+    # Bugfix: JFactoryPodioT template instantiation error with LinkCollections
+    patch(
+        "https://github.com/JeffersonLab/JANA2/pull/462/commits/c439fdd14bad2da6cf237c6d442f2a2f6632b67a.patch?full_index=1",
+        sha256="cc8d304a51912ae0519b9862bafb0fee56d1c1cd8b29523519bf04f6fc005d9f",
+        when="@2.4:2.4.2",
+    )
+
     def cmake_args(self):
         args = [
             self.define_from_variant("USE_CUDA", "cuda"),


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a patch for JANA2, v2.4.0 through v2.4.2, to prevent an error when using JFactoryPodioT with LinkCollections.

See https://github.com/JeffersonLab/JANA2/pull/462/commits/c439fdd14bad2da6cf237c6d442f2a2f6632b67a.