### PR TITLE
jana2: add podio dependency upper limit version due to operator-> on collections

### DIFF
--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -94,6 +94,7 @@ class Jana2(CMakePackage, CudaPackage):
 
     with when("+podio"):
         depends_on("podio@0.16.3:")
+        depends_on("podio@:1.4", when="@:2.4.2")  # uses operator-> on collections
         depends_on("podio@:0.17.3", when="@:2.1.2")  # uses podio/EventStore.h
         depends_on("py-jinja2")
         depends_on("py-pyyaml")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In https://github.com/AIDASoft/podio/pull/812 support for operator-> on podio collections was removed. JANA2 fixed this in 2.4.3.
