### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/.github/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "wdconinc"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/.github/" # Location of package manifests
+    directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Added GitHub Actions as a package ecosystem for Dependabot updates.