### PR TITLE
juggler: add v15.0.4

### DIFF
--- a/packages/juggler/package.py
+++ b/packages/juggler/package.py
@@ -17,6 +17,7 @@ class Juggler(CMakePackage):
 
     version("main", branch="main")
     version("master", branch="master", deprecated=True)
+    version("15.0.4", sha256="64f7638235d1a84faf0451e2138ef7dac1b0e571965918d8e19413684fcb681e")
     version("15.0.3", sha256="44edeca4439483459e0617f445543eb7c49cfd66a845326a6610bf5369c8b637")
     version("15.0.2", sha256="0b31fa2d3a94b2448f53d46525f09e564dce36e1679fb3e798469875c5ede957")
     version("15.0.1", sha256="9754887d2bcee2549d6cdf824b03c6cf5ffc22265a69cc095ebcdb3bd4572478")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds `juggler`, v15.0.4, which avoids requiring unused Acts components which have been removed in recent versions.