### PR TITLE
jana2: fix JANA_PLUGIN_PATH

### DIFF
--- a/packages/jana2/package.py
+++ b/packages/jana2/package.py
@@ -160,5 +160,5 @@ class Jana2(CMakePackage, CudaPackage):
         return args
 
     def setup_run_environment(self, env):
-        env.append_path("JANA_PLUGIN_PATH", join_path(self.prefix, "plugins"))
+        env.append_path("JANA_PLUGIN_PATH", self.prefix.lib.JANA.plugins)
         env.set("JANA_HOME", self.prefix)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the JANA plugin path. Currently (in eic-shell) this results in:
```
$ echo $JANA_PLUGIN_PATH 
/opt/local/lib/EICrecon/plugins:/opt/local/plugins
```
where `/opt/local/plugins` doesn't have any plugins. With this PR, the `JANA_PLUGIN_PATH` is correctly appended:
```
$ echo $JANA_PLUGIN_PATH 
/opt/local/lib/EICrecon/plugins:/opt/local/plugins:/opt/local/lib/JANA/plugins
```
(previous path still there since it doesn't get removed by changing the path in my development directory).

This directory `/opt/local/lib/JANA/plugins` indeed contains:
```
$ ls /opt/local/lib/JANA/plugins
CsvWriter.so                    JTest.so                 TimesliceExample.so  janapy.so    libCluster_rdict.pcm       lw_ascii_heatmap_writer.so  lw_random_hit_source.so        podio_random_hit_source.so
DstExample.so                   PodioFileReader.so       Tutorial.so          janarate.so  libHit_rdict.pcm           lw_csv_file_writer.so       podio_ascii_heatmap_writer.so  regressiontest.so
EventGroupExample.so            PodioFileWriter.so       janacontrol.so       janaroot.so  libjv_mainframe.rootmap    lw_hit_reco.so              podio_calibrations.so
InteractiveStreamingExample.so  RootDatamodelExample.so  janadot.so           janaview.so  libjv_mainframe_rdict.pcm  lw_protocluster.so          podio_protoclusterizer.so
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect `JANA_PLUGIN_PATH`)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __