### PR TITLE
fix(ci): change branch suffix from short-commit-hash to timestamp to avoid clobbering

### DIFF
--- a/.github/workflows/check-new-versions.yaml
+++ b/.github/workflows/check-new-versions.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: peter-evans/create-pull-request@v8
       with:
         path: eic-spack
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp
         title: New package versions found for ${{ steps.new_versions.outputs.files }}
         body: |
           New package versions found:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In https://github.com/eic/eic-spack/pull/819 a second run of the check-new-versions action cause the modifications to the branch to be overwritten. This PR forces the check-new-versions action to create a new unique branch each time it runs, preventing any clobbering with previous pull requests that may still be under review.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/pull/819#discussion_r2749687073)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
