### PR TITLE
epic: build with irt2

### DIFF
--- a/packages/epic/package.py
+++ b/packages/epic/package.py
@@ -183,6 +183,8 @@ class Epic(CMakePackage):
 
     depends_on("xrootd", when="@25.08.0:")
 
+    depends_on("irt2", when="@26.03.0:")
+
     depends_on("fmt +shared")
     depends_on("py-pyyaml")
     depends_on("py-jinja2")


### PR DESCRIPTION
Upcoming version of the ePIC geometry uses IRT2 structures to pass IRT geometry.