### PR TITLE
py-uproot: backport RNTuple v1.0.1.0 format support

### DIFF
--- a/packages/py-uproot/package.py
+++ b/packages/py-uproot/package.py
@@ -6,6 +6,7 @@ except:
     from spack.pkg.builtin.py_uproot import PyUproot as BuiltinPyUproot
 
 class PyUproot(BuiltinPyUproot):
+    # Backport upstream commit adding ROOT RNTuple v1.0.1.0 support to uproot.
     patch(
         "https://github.com/scikit-hep/uproot5/commit/88e69d47caa8cdb1ab0f47ffa27b2a6d113896d9.patch?full_index=1",
         sha256="a5120c569b5402870851d38ad4a0ed357629519010f4e38e0770acdd6a7eeb8e",

--- a/packages/py-uproot/package.py
+++ b/packages/py-uproot/package.py
@@ -1,0 +1,13 @@
+from spack.package import *
+
+try:
+    from spack_repo.builtin.packages.py_uproot.package import PyUproot as BuiltinPyUproot
+except:
+    from spack.pkg.builtin.py_uproot import PyUproot as BuiltinPyUproot
+
+class PyUproot(BuiltinPyUproot):
+    patch(
+        "https://github.com/scikit-hep/uproot5/commit/88e69d47caa8cdb1ab0f47ffa27b2a6d113896d9.patch?full_index=1",
+        sha256="a5120c569b5402870851d38ad4a0ed357629519010f4e38e0770acdd6a7eeb8e",
+        when="@5.5.2:5.7.1",
+    )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds RNTuple v1.0.1.0 support to older uproot versions.