### PR TITLE
acts: patch template<holder_t> for PodioTrack(State)Container

### DIFF
--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -20,7 +20,6 @@ class Acts(BuiltinActs):
         sha256="7914b2c186ac90caad930da254a65b6842bf269dd989035eff55d83de8af8b1e",
         when="@45.1.0:45.1.1",
     )
-    
     # Use (cached) runtime type hash in Acts::Any
     patch(
         "https://github.com/acts-project/acts/pull/4968.patch?full_index=1",

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -14,6 +14,13 @@ class Acts(BuiltinActs):
             if Spec(_spec) in Acts.dependencies:
                 del Acts.dependencies[Spec(_spec)]
 
+    # Use template<holder_t> for PodioTrack(State)Container
+    patch(
+        "https://github.com/acts-project/acts/pull/4974.diff?full_index=1",
+        sha256="7914b2c186ac90caad930da254a65b6842bf269dd989035eff55d83de8af8b1e",
+        when="@45.1.0:45.1.1",
+    )
+    
     # Use (cached) runtime type hash in Acts::Any
     patch(
         "https://github.com/acts-project/acts/pull/4968.patch?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR backports to Acts v45.1 the RefHolder functionality that allows ref and shared_ptr access to data collections (e.g. ActsPodioEdm).