### PR TITLE
geant4: add v11.4.1.east

### DIFF
--- a/spack_repo/eic/packages/geant4/package.py
+++ b/spack_repo/eic/packages/geant4/package.py
@@ -7,6 +7,7 @@ except ImportError:
 
 class Geant4(BuiltinGeant4):
     ## Versions with the eAST physics list
+    version("11.4.1.east", git="https://github.com/eic/geant4", branch="east-v11.4.1")
     version("11.4.0.east", git="https://github.com/eic/geant4", branch="east-v11.4.0")
     version("11.3.2.east", git="https://github.com/eic/geant4", branch="east-v11.3.2")
     version("11.3.1.east", git="https://github.com/eic/geant4", branch="east-v11.3.1")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the new `geant4` version v11.4.1, with the eAST physics lists backported into it.