### PR TITLE
eic_opticks: build with verbose

### DIFF
--- a/spack_repo/eic/packages/eic_opticks/package.py
+++ b/spack_repo/eic/packages/eic_opticks/package.py
@@ -38,6 +38,11 @@ class EicOpticks(CMakePackage, CudaPackage):
     depends_on("plog")
     depends_on("python")
 
+    def cmake_args(self):
+        return [
+            "--verbose",
+        ]
+
     def setup_build_environment(self, env):
         # GLM 0.9.9+ requires this for experimental GTX headers such as
         # dual_quaternion, which are reached via string_cast in this codebase.


### PR DESCRIPTION
This is for debugging stuck builds: https://eicweb.phy.anl.gov/containers/eic_container/-/pipelines/139914