### PR TITLE
fix: Add step to fetch base SHA in build workflow

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           path: eic-spack
           fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Fetch base SHA
+        run: |
+          cd eic-spack
+          git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
       - name: Set spack container tag
         id: set-tag
         run: |

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -156,7 +156,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ROOT", "root"),
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
-            "-DBUILD_EXAMPLES=OFF",
+            self.define("BUILD_EXAMPLES", False),
         ]
 
         # Podio

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -144,6 +144,10 @@ class Jana2(CMakePackage, CudaPackage):
         when="@2.4.3",
     )
 
+    def patch(self):
+        # workaround for https://github.com/eic/containers/issues/181
+        filter_file("add_subdirectory(src/examples)", "", "CMakeLists.txt")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("USE_CUDA", "cuda"),

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -145,7 +145,7 @@ class Jana2(CMakePackage, CudaPackage):
     )
     # Add BUILD_EXAMPLES and BUILD_TESTS CMake flags
     patch(
-        "https://github.com/JeffersonLab/JANA2/pull/243.patch?full_index=1",
+        "https://github.com/JeffersonLab/JANA2/pull/492.patch?full_index=1",
         sha256="dd30168e3968538cecbb1a4ff234e193c733956db2f4b8332df151cc297e8987",
         when="@2.4.3",
     )

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -143,10 +143,12 @@ class Jana2(CMakePackage, CudaPackage):
         sha256="a2590467a168a5771c02e4b361b1cc8f556a45e88683ec266169c1f0b3620d48",
         when="@2.4.3",
     )
-
-    def patch(self):
-        # workaround for https://github.com/eic/containers/issues/181
-        filter_file("add_subdirectory(src/examples)", "", "CMakeLists.txt")
+    # Add BUILD_EXAMPLES and BUILD_TESTS CMake flags
+    patch(
+        "https://github.com/JeffersonLab/JANA2/pull/243.patch?full_index=1",
+        sha256="dd30168e3968538cecbb1a4ff234e193c733956db2f4b8332df151cc297e8987",
+        when="@2.4.3",
+    )
 
     def cmake_args(self):
         args = [
@@ -154,6 +156,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ROOT", "root"),
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
+            "-DBUILD_EXAMPLES=OFF",
         ]
 
         # Podio


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Aims to fix the build failure in https://github.com/eic/eic-spack/actions/runs/23616096306/job/68783814546?pr=855 by explicitly fetching the commit in question. Not quite sure why the FETCH_DEPTH determination goes off here now...