### PR TITLE
jana2: disable building tests

### DIFF
--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -157,7 +157,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
             self.define("BUILD_EXAMPLES", False),
-            self.define("BUILD_TESTS", false),
+            self.define("BUILD_TESTS", False),
         ]
 
         # Podio

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -157,7 +157,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
             self.define("BUILD_EXAMPLES", False),
-            self.define("BUILD_TESTS", False),
+            self.define("BUILD_TESTS", self.run_tests),
         ]
 
         # Podio

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -156,7 +156,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ROOT", "root"),
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
-            self.define("BUILD_EXAMPLES", False),
+            self.define("BUILD_EXAMPLES", self.run_tests),
             self.define("BUILD_TESTS", self.run_tests),
         ]
 

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -157,6 +157,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
             self.define("BUILD_EXAMPLES", False),
+            self.define("BUILD_TESTS", false),
         ]
 
         # Podio


### PR DESCRIPTION
```
#19 371.2 /tmp/root/spack-stage/spack-stage-jana2-2.4.3-hiv4j7v7tdycfdnl5limy5xo2hugdqa2/spack-src/src/programs/unit_tests/Components/JHasInputsTests.cc:8:10: fatal error: PodioDatamodel/ExampleHitCollection.h: No such file or directory
#19 371.2     8 | #include <PodioDatamodel/ExampleHitCollection.h>
#19 371.2       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#19 371.2 compilation terminated.
```