### PR TITLE
fix: py-tensorflow: patch cast ambiguity with GCC in dtensor/mlir/{shape_utils,spmd_expansion}.cc

### DIFF
--- a/spack_repo/eic/packages/py_tensorflow/package.py
+++ b/spack_repo/eic/packages/py_tensorflow/package.py
@@ -12,8 +12,9 @@ class PyTensorflow(BuiltinPyTensorflow):
         when="@2.15:2.19",
     )
 
-    # tensorflow/dtensor/mlir/shape_utils.cc uses unqualified cast<mlir::OpResult>,
-    # which is ambiguous with Eigen::internal::cast under GCC. Qualify it explicitly.
+    # tensorflow/dtensor/mlir/shape_utils.cc and spmd_expansion.cc use unqualified
+    # cast<mlir::...>, which is ambiguous with Eigen::internal::cast under GCC.
+    # Qualify all occurrences explicitly with llvm::cast.
     @run_before("build")
     def patch_gcc_cast_ambiguity(self):
         if self.spec.satisfies("@2.20: %gcc"):
@@ -21,4 +22,9 @@ class PyTensorflow(BuiltinPyTensorflow):
                 r"return ExtractGlobalOutputShape\(cast<mlir::OpResult>",
                 "return ExtractGlobalOutputShape(llvm::cast<mlir::OpResult>",
                 "tensorflow/dtensor/mlir/shape_utils.cc",
+            )
+            filter_file(
+                r"cast<mlir::BlockArgument>",
+                "llvm::cast<mlir::BlockArgument>",
+                "tensorflow/dtensor/mlir/spmd_expansion.cc",
             )

--- a/spack_repo/eic/packages/py_tensorflow/package.py
+++ b/spack_repo/eic/packages/py_tensorflow/package.py
@@ -13,8 +13,9 @@ class PyTensorflow(BuiltinPyTensorflow):
     )
 
     # tensorflow/dtensor/mlir/shape_utils.cc and spmd_expansion.cc use unqualified
-    # cast<mlir::...>, which is ambiguous with Eigen::internal::cast under GCC.
-    # Qualify all occurrences explicitly with llvm::cast.
+    # cast<mlir::...> and isa<mlir::...>, which GCC cannot resolve without the
+    # llvm:: namespace qualifier (ambiguous with Eigen::internal::cast, or simply
+    # not declared in scope). Qualify all occurrences explicitly.
     @run_before("build")
     def patch_gcc_cast_ambiguity(self):
         if self.spec.satisfies("@2.20: %gcc"):
@@ -26,5 +27,10 @@ class PyTensorflow(BuiltinPyTensorflow):
             filter_file(
                 r"cast<mlir::BlockArgument>",
                 "llvm::cast<mlir::BlockArgument>",
+                "tensorflow/dtensor/mlir/spmd_expansion.cc",
+            )
+            filter_file(
+                r"isa<mlir::TF::ResourceType>",
+                "llvm::isa<mlir::TF::ResourceType>",
                 "tensorflow/dtensor/mlir/spmd_expansion.cc",
             )

--- a/spack_repo/eic/packages/py_tensorflow/package.py
+++ b/spack_repo/eic/packages/py_tensorflow/package.py
@@ -14,7 +14,7 @@ class PyTensorflow(BuiltinPyTensorflow):
 
     # tensorflow/dtensor/mlir/shape_utils.cc uses unqualified cast<mlir::OpResult>,
     # which is ambiguous with Eigen::internal::cast under GCC. Qualify it explicitly.
-    @run_before("install")
+    @run_before("build")
     def patch_gcc_cast_ambiguity(self):
         if self.spec.satisfies("@2.20: %gcc"):
             filter_file(

--- a/spack_repo/eic/packages/py_tensorflow/package.py
+++ b/spack_repo/eic/packages/py_tensorflow/package.py
@@ -11,3 +11,14 @@ class PyTensorflow(BuiltinPyTensorflow):
         sha256="f623d5d833ba0185c9b6ef4a98b90069a73bea84e45381995a3db8150280c896",
         when="@2.15:2.19",
     )
+
+    # tensorflow/dtensor/mlir/shape_utils.cc uses unqualified cast<mlir::OpResult>,
+    # which is ambiguous with Eigen::internal::cast under GCC. Qualify it explicitly.
+    @run_before("install")
+    def patch_gcc_cast_ambiguity(self):
+        if self.spec.satisfies("@2.20: %gcc"):
+            filter_file(
+                r"return ExtractGlobalOutputShape\(cast<mlir::OpResult>",
+                "return ExtractGlobalOutputShape(llvm::cast<mlir::OpResult>",
+                "tensorflow/dtensor/mlir/shape_utils.cc",
+            )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`tensorflow/dtensor/mlir/shape_utils.cc:76` uses unqualified `cast<mlir::OpResult>` which is ambiguous with `Eigen::internal::cast` under GCC. Same in `tensorflow/dtensor/mlir/spmd_expansion.cc:191`. This PR uses `llvm::cast` explicitly.