### PR TITLE
jana2: yank 2026.01

### DIFF
--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -22,8 +22,9 @@ class Jana2(CMakePackage, CudaPackage):
 
     version("master", branch="master")
     version("2026.02.00", sha256="431a70d56019cf076fe80dc4317849ef5ad448173d4a0a7bf0325607aafba545")
-    version("2026.01.01", sha256="2ccb1d6cc695df1ea9aa04667607534d89fb21c6f0692ebbf2ea9bf0e409621c")
-    version("2026.01.00", sha256="575a202f5b7e153f9e25274fc6367c2a935aa23fb2ad3331c87d2fbfe08154ff")
+    # JANA2 2026.01 never worked with EICrecon, so it is not included here
+    # version("2026.01.01", sha256="2ccb1d6cc695df1ea9aa04667607534d89fb21c6f0692ebbf2ea9bf0e409621c")
+    # version("2026.01.00", sha256="575a202f5b7e153f9e25274fc6367c2a935aa23fb2ad3331c87d2fbfe08154ff")
     version("2.4.3", sha256="9d023f2225ad28d19c0e663de180d08e96900c4f76e3992faa946926cfa9cfcb")
     version("2.4.2", sha256="3536c2885745dd3e0ce3e068d09537a93850bee6e5a2ca8a559044ce1a7f985a")
     version("2.4.1", sha256="d3fabb532bbc6773fcd40fbdac714079b25bf69edd8f528395be0c7909bf8265")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes jana2 2026.01.00 and 2026.01.01, both of which were not compatible with EICrecon.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: prevent incompatible versions from getting installed)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
