### PR TITLE
fix: spack audit fixes for missing docstring (use base package)

### DIFF
--- a/spack_repo/eic/packages/acts/package.py
+++ b/spack_repo/eic/packages/acts/package.py
@@ -8,6 +8,8 @@ except ImportError:
 
 
 class Acts(BuiltinActs):
+    __doc__ = BuiltinActs.__doc__
+
     def __init__(self, spec):
         super(Acts, self).__init__(spec)
         # HACK Remove upstream limitations on podio@:0

--- a/spack_repo/eic/packages/dd4hep/package.py
+++ b/spack_repo/eic/packages/dd4hep/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Dd4hep(BuiltinDd4hep):
+    __doc__ = BuiltinDd4hep.__doc__
+
     version("1.32.1", sha256="f47fbede967b609e142c3116d23b4993f9d57fbae28a1739b5333503bc498883")
     version("1.32", sha256="8bde4eab9af9841e040447282ea7df3a16e4bcec587c3a1e32f41987da9b1b4d")
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")

--- a/spack_repo/eic/packages/epic_eic/package.py
+++ b/spack_repo/eic/packages/epic_eic/package.py
@@ -2,4 +2,4 @@ from spack_repo.eic.packages.epic.package import Epic
 
 
 class EpicEic(Epic):
-    pass
+    __doc__ = Epic.__doc__

--- a/spack_repo/eic/packages/gaudi/package.py
+++ b/spack_repo/eic/packages/gaudi/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Gaudi(BuiltinGaudi):
+    __doc__ = BuiltinGaudi.__doc__
+
     patch(
         "https://gitlab.cern.ch/gaudi/Gaudi/-/commit/03db151003d5207795ae8ec96aaf2f5f8a9ea008.diff",
         sha256="e73f45f10ea4a143a05c53a468233ceaad1a8ec22dee9877d178a3c9ee46c70f",

--- a/spack_repo/eic/packages/geant4/package.py
+++ b/spack_repo/eic/packages/geant4/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Geant4(BuiltinGeant4):
+    __doc__ = BuiltinGeant4.__doc__
+
     ## Versions with the eAST physics list
     version("11.4.1.east", git="https://github.com/eic/geant4", branch="east-v11.4.1")
     version("11.4.0.east", git="https://github.com/eic/geant4", branch="east-v11.4.0")

--- a/spack_repo/eic/packages/hepmc3/package.py
+++ b/spack_repo/eic/packages/hepmc3/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Hepmc3(BuiltinHepmc3):
+    __doc__ = BuiltinHepmc3.__doc__
+
     version("3.2.5", sha256="cd0f75c80f75549c59cc2a829ece7601c77de97cb2a5ab75790cac8e1d585032")
     patch(
         "ReaderPlugin.patch",

--- a/spack_repo/eic/packages/k4actstracking/package.py
+++ b/spack_repo/eic/packages/k4actstracking/package.py
@@ -13,6 +13,8 @@ except ImportError:
 
 
 class K4actstracking(BuiltinK4actstracking):
+    __doc__ = BuiltinK4actstracking.__doc__
+
     def patch(self):
         filter_file(
             "m_obj.write(m_outputFileName)",

--- a/spack_repo/eic/packages/k4fwcore/package.py
+++ b/spack_repo/eic/packages/k4fwcore/package.py
@@ -13,6 +13,8 @@ except ImportError:
 
 
 class K4fwcore(BuiltinK4fwcore):
+    __doc__ = BuiltinK4fwcore.__doc__
+
     # Remove rootUtils.h header that has become unnecessary
     patch(
         "https://github.com/key4hep/k4FWCore/commit/70c9c113f48d941822066430f48eee8be007f49b.patch?full_index=1",

--- a/spack_repo/eic/packages/podio/package.py
+++ b/spack_repo/eic/packages/podio/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Podio(BuiltinPodio):
+    __doc__ = BuiltinPodio.__doc__
+
     patch(
         "https://github.com/AIDASoft/podio/pull/423.patch?full_index=1",
         sha256="a88278b99a579fa1e8b8027f5ce8baad85d5870f648620d19dd40cf35880aa9d",

--- a/spack_repo/eic/packages/py_minkowskiengine/package.py
+++ b/spack_repo/eic/packages/py_minkowskiengine/package.py
@@ -9,5 +9,7 @@ except ImportError:
 
 
 class PyMinkowskiengine(BuiltinPyMinkowskiengine):
+    __doc__ = BuiltinPyMinkowskiengine.__doc__
+
     git = "https://github.com/NVIDIA/MinkowskiEngine"
     version("master", branch="master")

--- a/spack_repo/eic/packages/py_tensorflow/package.py
+++ b/spack_repo/eic/packages/py_tensorflow/package.py
@@ -9,6 +9,8 @@ except ImportError:
 
 
 class PyTensorflow(BuiltinPyTensorflow):
+    __doc__ = BuiltinPyTensorflow.__doc__
+
     patch(
         "https://github.com/tensorflow/tensorflow/pull/90579.diff?full_index=1",
         sha256="f623d5d833ba0185c9b6ef4a98b90069a73bea84e45381995a3db8150280c896",

--- a/spack_repo/eic/packages/py_uproot/package.py
+++ b/spack_repo/eic/packages/py_uproot/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class PyUproot(BuiltinPyUproot):
+    __doc__ = BuiltinPyUproot.__doc__
+
     patch(
         "https://github.com/scikit-hep/uproot5/commit/88e69d47caa8cdb1ab0f47ffa27b2a6d113896d9.patch?full_index=1",
         sha256="a5120c569b5402870851d38ad4a0ed357629519010f4e38e0770acdd6a7eeb8e",

--- a/spack_repo/eic/packages/rivet/package.py
+++ b/spack_repo/eic/packages/rivet/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Rivet(BuiltinRivet):
+    __doc__ = BuiltinRivet.__doc__
+
     with when("@4.1:"):
         variant(
             "plugin-match",

--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -7,6 +7,8 @@ except ImportError:
 
 
 class Root(BuiltinRoot):
+    __doc__ = BuiltinRoot.__doc__
+
     version("6.32.14", sha256="dfb5193127ff80ebfa10e6a4dcdf56eeec0eface65fc3de347d853ae9653aeff")
     version("6.32.12", sha256="2e41968aeb0406ee31c30af9c046143099b251846e0839cb04f4e960c7893e19")
     version("6.32.10", sha256="5a896804ec153685e8561adaa4e546b708139c484280aa6713a0a178f5b7f98b")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the (new) audit checks for valid docstrings, which are now failing in https://github.com/eic/eic-spack/actions/runs/24540703161/job/71745651709?pr=837#step:8:41

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: failing spack audit)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Copilot replaced the 14 instances after a human described the pattern to follow.