### PR TITLE
fix: apply minor package fixes from PR #837

### DIFF
--- a/spack_repo/eic/packages/afterburner/package.py
+++ b/spack_repo/eic/packages/afterburner/package.py
@@ -33,11 +33,14 @@ class Afterburner(CMakePackage):
     variant("root", default=False, description="Support reading ROOT files")
     variant("zlib", default=True, description="Support reading compressed files")
 
+    # REQUIRED in abconv find_package ROOT
+    requires("+root")
+
     depends_on("c", type="build", when="@:0.1.3")
     depends_on("cxx", type="build")
 
     depends_on("gsl")
-    depends_on("hepmc3")
+    depends_on("hepmc3 +rootio")
     depends_on("clhep")
     depends_on("yaml-cpp")
     depends_on("root", when="+root")

--- a/spack_repo/eic/packages/bmf/package.py
+++ b/spack_repo/eic/packages/bmf/package.py
@@ -23,5 +23,6 @@ class Bmf(CMakePackage):
     version("master", branch="master")
     version("2020-04-13", commit="d00c54dc812bfa1804acb5fe370bb9c27b3539f9")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@2.8.10:", type="build")

--- a/spack_repo/eic/packages/dawn/package.py
+++ b/spack_repo/eic/packages/dawn/package.py
@@ -47,7 +47,7 @@ class Dawn(MakefilePackage):
     depends_on("tcl")
     depends_on("tk")
 
-    ## Patch to ensure wish is called correctly
+    # Patch to ensure wish is called correctly
     patch("exec.patch")
     patch("install.patch")
 

--- a/spack_repo/eic/packages/dawncut/package.py
+++ b/spack_repo/eic/packages/dawncut/package.py
@@ -37,10 +37,10 @@ class Dawncut(MakefilePackage):
     def unpack(self, spec, prefix):
         # Untar inner tar files
         def members(tf, tld):
-            l = len(tld)
+            tld_len = len(tld)
             for member in tf.getmembers():
                 if member.path.startswith(tld):
-                    member.path = member.path[l:]
+                    member.path = member.path[tld_len:]
                     yield member
 
         with working_dir(self.stage.source_path):
@@ -51,7 +51,6 @@ class Dawncut(MakefilePackage):
 
     def repatch(self, spec, prefix):
         # Patch to add install directive to Makefile
-        src = self.stage.source_path
         patches = self.package_dir
         which("patch")("-N", "-l", "-p1", "-i", join_path(patches, "install.patch"))
 

--- a/spack_repo/eic/packages/eicd/package.py
+++ b/spack_repo/eic/packages/eicd/package.py
@@ -32,8 +32,7 @@ class Eicd(CMakePackage):
     depends_on("py-jinja2", type="build")
     depends_on("py-pyyaml", type="build")
 
-    depends_on("edm4hep@0.4.1:", when="@2:")
-    depends_on("podio@0.14.1:", when="@2:")
+    depends_on("podio@0.14.1:0")
     depends_on("root@6.08:")
 
     def cmake_args(self):

--- a/spack_repo/eic/packages/eicroot/package.py
+++ b/spack_repo/eic/packages/eicroot/package.py
@@ -24,7 +24,7 @@ class Eicroot(CMakePackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("root@6.18.04:")
+    depends_on("root")
     depends_on("geant3-vmc")
     depends_on("geant4-vmc")
 

--- a/spack_repo/eic/packages/farmhash/package.py
+++ b/spack_repo/eic/packages/farmhash/package.py
@@ -19,6 +19,7 @@ class Farmhash(AutotoolsPackage):
 
     version("master", branch="master")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build", when="@master")

--- a/spack_repo/eic/packages/fluka/package.py
+++ b/spack_repo/eic/packages/fluka/package.py
@@ -1,5 +1,4 @@
 import os
-import tarfile
 
 from spack.package import *
 

--- a/spack_repo/eic/packages/geant4/package.py
+++ b/spack_repo/eic/packages/geant4/package.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 class Geant4(BuiltinGeant4):
-    ## Versions with the eAST physics list
+    # Versions with the eAST physics list
     version("11.4.1.east", git="https://github.com/eic/geant4", branch="east-v11.4.1")
     version("11.4.0.east", git="https://github.com/eic/geant4", branch="east-v11.4.0")
     version("11.3.2.east", git="https://github.com/eic/geant4", branch="east-v11.3.2")
@@ -22,7 +22,7 @@ class Geant4(BuiltinGeant4):
 
     patch("G4LogicalSkinSurface.patch", when="@11.2:11.2.1")
 
-    ## Fix commands in /particle/property/decay/
+    # Fix commands in /particle/property/decay/
     patch(
         "https://github.com/Geant4/geant4/commit/e32bc92498d87fb42829b08348d7fad89bc89404.diff?full_index=1",
         sha256="a63b098f3214eaf4b5f34b3e434603b1cdbd13c919456782e933cd7422a45d99",

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -59,8 +59,6 @@ class Jana2(CMakePackage, CudaPackage):
         depends_on("py-jinja2")
         depends_on("py-pyyaml")
 
-    conflicts("+cuda", when="@:2.0", msg="CUDA support only available in 2.1 and later")
-
     # Stop printing the component summary
     patch(
         "https://github.com/JeffersonLab/JANA2/commit/8ed069da7f307d12cafd6b075eae8401aec6f5aa.diff?full_index=1",

--- a/spack_repo/eic/packages/juggler/package.py
+++ b/spack_repo/eic/packages/juggler/package.py
@@ -35,6 +35,7 @@ class Juggler(CMakePackage):
     depends_on("dd4hep +ddg4")
 
     depends_on("gaudi@36:")
+    conflicts("^gaudi@37:38 ~gaudialg", when="@:14", msg="GaudiAlgLib required through v14")
 
     depends_on("acts +json +dd4hep", when="@15.0.4:")
     depends_on("acts +json +tgeo +dd4hep", when="@14.2:15.0.3")

--- a/spack_repo/eic/packages/nanocernlib/package.py
+++ b/spack_repo/eic/packages/nanocernlib/package.py
@@ -22,5 +22,10 @@ class Nanocernlib(CMakePackage):
     version("master", branch="master")
     version("1.0.0", sha256="00b23d2613272951c1771d917ec0a7c30920e9d114caf1b421c44a806a06356a")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("cmake", type="build")
+
+    def setup_build_environment(self, env):
+        env.append_flags("CFLAGS", "-Wno-implicit-function-declaration")

--- a/spack_repo/eic/packages/pepsi/package.py
+++ b/spack_repo/eic/packages/pepsi/package.py
@@ -35,7 +35,6 @@ class Pepsi(MakefilePackage):
             filter_file("-g -m64", "-g", "Makefile")
 
     def setup_build_environment(self, env):
-        spec = self.spec
         env.set("EICDIRECTORY", self.spec.prefix)
 
     def install(self, spec, prefix):

--- a/spack_repo/eic/packages/pyrobird/package.py
+++ b/spack_repo/eic/packages/pyrobird/package.py
@@ -7,11 +7,6 @@ from spack_repo.builtin.build_systems.python import PythonPackage
 
 from spack.package import *
 
-try:
-    import spack.llnl.util.tty as tty
-except ImportError:
-    import llnl.util.tty as tty
-
 
 class Pyrobird(PythonPackage):
     """Phoenix based event display."""

--- a/spack_repo/eic/packages/tensorflow_lite/package.py
+++ b/spack_repo/eic/packages/tensorflow_lite/package.py
@@ -84,8 +84,8 @@ class TensorflowLite(CMakePackage):
         # Instal library
         mkdirp(self.prefix.lib)
         with working_dir(self.build_directory):
-            for l in find(".", "libtensorflow-lite.*", recursive=False):
-                install(l, self.prefix.lib)
+            for lib_file in find(".", "libtensorflow-lite.*", recursive=False):
+                install(lib_file, self.prefix.lib)
 
         # Install headers for tensorflow itself
         mkdirp(self.prefix.include)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR applies various minor issues from #837 in a dedicated PR. They are:
- afterburner: require +root variant (needed by abconv), depend on hepmc3 +rootio
- bmf: add missing depends_on("c") build dependency
- dawn: fix double-hash comment style
- dawncut: rename shadowing variable l->tld_len, remove unused src variable
- eicd: simplify podio constraint to @0.14.1:0, drop redundant edm4hep constraint
- eicroot: relax root version constraint (remove @6.18.04: lower bound)
- farmhash: add missing depends_on("c") build dependency
- fluka: remove unused import tarfile
- geant4: fix double-hash comment style
- jana2: remove obsolete +cuda conflict (already inapplicable for supported versions)
- juggler: add conflict for gaudi@37:38 ~gaudialg when @:14 (GaudiAlgLib required)
- nanocernlib: add missing c/cxx build deps, suppress -Wno-implicit-function-declaration
- pepsi: remove unused local variable spec in setup_build_environment
- pyrobird: remove unused tty import try/except block
- tensorflow_lite: rename shadowing variable l->lib_file

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: minor fixes, mostly to older versions)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Human made the changes in #837 based on failing builds there, then AI extracted them and put them in this branch.