### PR TITLE
acts: backport Gen3 DD4hep construction

### DIFF
--- a/spack_repo/eic/packages/acts/package.py
+++ b/spack_repo/eic/packages/acts/package.py
@@ -20,7 +20,7 @@ class Acts(BuiltinActs):
     # Gen3 DD4hep construction
     patch(
         "https://github.com/acts-project/acts/pull/5193.patch?full_index=1",
-        sha256s="bee084dd48b596312642c4c815d183c018b4a37735bc8f331a7b8cb3f50a269c",
+        sha256="bee084dd48b596312642c4c815d183c018b4a37735bc8f331a7b8cb3f50a269c",
         when="@45.2:46.2",
     )
 

--- a/spack_repo/eic/packages/acts/package.py
+++ b/spack_repo/eic/packages/acts/package.py
@@ -17,6 +17,13 @@ class Acts(BuiltinActs):
             if Spec(_spec) in Acts.dependencies:
                 del Acts.dependencies[Spec(_spec)]
 
+    # Gen3 DD4hep construction
+    patch(
+        "https://github.com/acts-project/acts/pull/5193.patch?full_index=1",
+        sha256s="bee084dd48b596312642c4c815d183c018b4a37735bc8f331a7b8cb3f50a269c",
+        when="@45.2:46.2",
+    )
+
     # Use template<holder_t> for PodioTrack(State)Container
     patch(
         "https://github.com/acts-project/acts/pull/4974.diff?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR backports the Acts Gen3 DD4hep construction https://github.com/acts-project/acts/pull/5193 into acts v45 so we can roll this out in development sooner.

Tested that this cherry-picks cleanly into 45.2.0, and that it is included in release 46.3.0. Checked with AI that there are no hidden dependencies that would affect functionality outside of cherry-pick merge conflicts.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: Acts Gen3 DD4hep construction)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
