### PR TITLE
style: add pyproject.toml with ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[project]
-name = "eic-spack"
-description = "EIC Spack package repository"
-requires-python = ">=3.6"
-
 [tool.ruff]
 line-length = 99
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "eic-spack"
+description = "EIC Spack package repository"
+requires-python = ">=3.6"
+
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+extend-select = ["I"]
+ignore = ["E731", "E203", "F403", "F811"]
+
+[tool.ruff.lint.per-file-ignores]
+"spack_repo/*/packages/*/package.py" = ["F403", "F405", "F811", "F821"]


### PR DESCRIPTION
Spack switched to ruff for style checks. This adds a minimal `pyproject.toml` to configure ruff so that CI style checks pass.

The key fix is the `per-file-ignores` section that suppresses `F403`, `F405`, `F811`, and `F821` for package files, which use `from spack.package import *` (star imports are expected in Spack packages).

Fixes the CI failure in #887.