### PR TITLE
ci: replace flake8 config step with ruff per-file-ignores patch

### DIFF
--- a/.github/workflows/style_and_audit.yml
+++ b/.github/workflows/style_and_audit.yml
@@ -41,11 +41,13 @@ jobs:
         with:
           ref: develop
 
-      - name: Configure flake8 for package repository
+      - name: Configure ruff for package repository
         run: |
           SPACK_ROOT=$(spack location -r)
-          # Add our package repository paths to Spack's flake8 config
-          sed -i '/var\/spack\/\*\/package.py/a\  ../eic-spack/spack_repo/*/packages/*/package.py:F403,F405,F821' ${SPACK_ROOT}/.flake8
+          # Add generic package.py pattern to Spack's ruff config so that
+          # packages in external repos (passed as ../relative paths) are covered.
+          # Path-based patterns don't match files outside the spack root.
+          sed -i '/\[tool\.ruff\.lint\.per-file-ignores\]/a\  "package.py" = ["F403", "F405", "F811", "F821"]' ${SPACK_ROOT}/pyproject.toml
 
       - name: Add package repository
         run: |

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -26,8 +26,12 @@ class Jana2(CMakePackage, CudaPackage):
         "2026.02.00", sha256="431a70d56019cf076fe80dc4317849ef5ad448173d4a0a7bf0325607aafba545"
     )
     # JANA2 2026.01 never worked with EICrecon, so it is not included here
-    # version("2026.01.01", sha256="2ccb1d6cc695df1ea9aa04667607534d89fb21c6f0692ebbf2ea9bf0e409621c")
-    # version("2026.01.00", sha256="575a202f5b7e153f9e25274fc6367c2a935aa23fb2ad3331c87d2fbfe08154ff")
+    # version(
+    #     "2026.01.01", sha256="2ccb1d6cc695df1ea9aa04667607534d89fb21c6f0692ebbf2ea9bf0e409621c"
+    # )
+    # version(
+    #     "2026.01.00", sha256="575a202f5b7e153f9e25274fc6367c2a935aa23fb2ad3331c87d2fbfe08154ff"
+    # )
     version("2.4.3", sha256="9d023f2225ad28d19c0e663de180d08e96900c4f76e3992faa946926cfa9cfcb")
     version("2.4.2", sha256="3536c2885745dd3e0ce3e068d09537a93850bee6e5a2ca8a559044ce1a7f985a")
     version("2.4.1", sha256="d3fabb532bbc6773fcd40fbdac714079b25bf69edd8f528395be0c7909bf8265")


### PR DESCRIPTION
## Summary

`spack style` now uses ruff instead of flake8. The previous step patched Spack's `.flake8` config to suppress `F403`/`F405`/`F821` for external package files, but that file no longer exists.

This also fixes the two remaining `jana2` lines that have issues with `ruff` but were fine in `black` and `flake8`.

## Root cause

When `spack style` invokes ruff, it:
1. Sets the working directory to the spack root
2. Passes all files as paths **relative to the spack root**

Files in external repos therefore arrive as `../eic-spack/spack_repo/eic/packages/*/package.py`. Ruff's `per-file-ignores` matches path-based patterns against paths relative to the config file's directory (the spack root), so any pattern like `spack_repo/*/packages/*/package.py` never matches because of the leading `../`.

## Fix

Patch Spack's `pyproject.toml` at CI time to add a **filename-only** pattern:

```toml
"package.py" = ["F403", "F405", "F811", "F821"]
```

Ruff matches filename-only patterns (no path separators) against the basename alone, regardless of location — so this correctly covers all `package.py` files in any external repo.