### PR TITLE
py-uproot: add comment line for patch

### DIFF
--- a/spack_repo/eic/packages/py_uproot/package.py
+++ b/spack_repo/eic/packages/py_uproot/package.py
@@ -9,6 +9,7 @@ except ImportError:
 class PyUproot(BuiltinPyUproot):
     __doc__ = BuiltinPyUproot.__doc__
 
+    # Support RNTuple v1.0.1.0 format (attribute set record frame)
     patch(
         "https://github.com/scikit-hep/uproot5/commit/88e69d47caa8cdb1ab0f47ffa27b2a6d113896d9.patch?full_index=1",
         sha256="a5120c569b5402870851d38ad4a0ed357629519010f4e38e0770acdd6a7eeb8e",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds a comment on the patch that adds support for RNTuple v1.0.1.0 format (attribute set record frame). No actual code changes.

### What is the urgency of this PR?
- [ ] High
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: missing docs)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
