### PR TITLE
feat: add rntuple variant to py-epic-capybara

### DIFF
--- a/spack_repo/eic/packages/py_epic_capybara/package.py
+++ b/spack_repo/eic/packages/py_epic_capybara/package.py
@@ -26,7 +26,11 @@ class PyEpicCapybara(PythonPackage):
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-hatchling", type="build")
 
-    variant("rntuple", default=False, description="Support reading RNTuple files (requires uproot>=5.7.0)")
+    variant(
+        "rntuple",
+        default=False,
+        description="Support reading RNTuple files (requires uproot>=5.7.0)",
+    )
 
     depends_on("py-awkward", type=("build", "run"))
     depends_on("py-bokeh", type=("build", "run"))

--- a/spack_repo/eic/packages/py_epic_capybara/package.py
+++ b/spack_repo/eic/packages/py_epic_capybara/package.py
@@ -26,6 +26,8 @@ class PyEpicCapybara(PythonPackage):
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-hatchling", type="build")
 
+    variant("rntuple", default=False, description="Support reading RNTuple files (requires uproot>=5.7.0)")
+
     depends_on("py-awkward", type=("build", "run"))
     depends_on("py-bokeh", type=("build", "run"))
     depends_on("py-click", type=("build", "run"))
@@ -34,3 +36,4 @@ class PyEpicCapybara(PythonPackage):
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-uproot", type=("build", "run"))
+    depends_on("py-uproot@5.7:", type=("build", "run"), when="+rntuple")


### PR DESCRIPTION
## Summary

Adds an optional `+rntuple` variant to the `py-epic-capybara` spack package, mirroring the `epic-capybara[rntuple]` pip extra introduced in [eic/epic-capybara#33](https://github.com/eic/epic-capybara/pull/33).

## Changes

```python
variant("rntuple", default=False, description="Support reading RNTuple files (requires uproot>=5.7.0)")
depends_on("py-uproot@5.7:", type=("build", "run"), when="+rntuple")
```

When `+rntuple` is enabled, spack constrains `py-uproot` to `@5.7:`, which contains the rewritten `read_cluster_range()` array-reading code needed for RNTuple files written by ROOT 6.38.00+ (format v1.0.1.0). Without the variant, any version of `py-uproot` is accepted (existing behavior).

## Related

- eic/epic-capybara#33 — adds the `[rntuple]` pip extra
- eic/containers#243 — upgrades uproot to 5.7.1 in the eic-shell nightly
- eic/EICrecon#2469 — the EICrecon CI RNTuple conversion that requires all of the above