### PR TITLE
eic-smear: depends_on hepmc3 +rootio when @1.1.10:

### DIFF
--- a/spack_repo/eic/packages/eic_smear/package.py
+++ b/spack_repo/eic/packages/eic_smear/package.py
@@ -55,6 +55,7 @@ class EicSmear(CMakePackage):
     depends_on("root", when="-pythia6")
     depends_on("zlib")
     depends_on("hepmc3")
+    depends_on("hepmc3 +rootio", when="@1.1.10:")
     depends_on("pythia6", when="+pythia6")
 
     conflicts(


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
`eic-smear` has depended on the ROOT IO functionality of HepMC3 since https://github.com/eic/eic-smear/commit/572ac09b, i.e. 1.1.10. This PR ensures that's the case in the spack package, and avoids build failures.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/24641091769/job/72045302621?pr=837#step:14:1758)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
