### PR TITLE
eicrecon: depends on root +tmva when @1.14:1.36

### DIFF
--- a/spack_repo/eic/packages/eicrecon/package.py
+++ b/spack_repo/eic/packages/eicrecon/package.py
@@ -75,6 +75,7 @@ class Eicrecon(CMakePackage):
     depends_on("acts@30:")
 
     depends_on("root")
+    depends_on("root +tmva", when="@1.14:")
     depends_on("fastjet")
     depends_on("fjcontrib")
     depends_on("fmt")

--- a/spack_repo/eic/packages/eicrecon/package.py
+++ b/spack_repo/eic/packages/eicrecon/package.py
@@ -75,7 +75,7 @@ class Eicrecon(CMakePackage):
     depends_on("acts@30:")
 
     depends_on("root")
-    depends_on("root +tmva", when="@1.14:")
+    depends_on("root +tmva", when="@1.14:1.36")
     depends_on("fastjet")
     depends_on("fjcontrib")
     depends_on("fmt")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds a dependency on ROOT::TMVA for EICrecon v1.14 and later.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
