### PR TITLE
online-distribution: add new package with ePIC branch version

### DIFF
--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -38,7 +38,6 @@ class OnlineDistribution(Package):
         filter_file(r" -I/opt/local/include", "", "eventlibraries/Makefile.am")
 
     def install(self, spec, prefix):
-        env["ONLINE_MAIN"] = prefix
         for subdir in ["eventlibraries", "pmonitor"]:
             with working_dir(subdir):
                 autoreconf = Executable("autoreconf")
@@ -47,3 +46,6 @@ class OnlineDistribution(Package):
                 configure(f"--prefix={prefix}")
                 make()
                 make("install")
+
+    def setup_run_environment(self, env):
+        env.set("ONLINE_MAIN", self.prefix)

--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OnlineDistribution(Package):
+    """sPHENIX/EIC online data distribution system including event libraries
+    and performance monitoring tools."""
+
+    homepage = "https://github.com/sPHENIX-Collaboration/online_distribution"
+    git = "https://github.com/sPHENIX-Collaboration/online_distribution.git"
+
+    maintainers("wdconinc")
+
+    license("UNKNOWN", checked_by="wdconinc")
+
+    version("ePIC", branch="ePIC")
+
+    depends_on("cxx", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("gmake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("root")
+    depends_on("boost")
+    depends_on("lzo")
+    depends_on("zlib-api")
+    depends_on("bzip2")
+
+    def patch(self):
+        # Remove hardcoded /opt/local paths from eventlibraries/Makefile.am
+        filter_file(r" -L/opt/local/lib", "", "eventlibraries/Makefile.am")
+        filter_file(r" -I/opt/local/include", "", "eventlibraries/Makefile.am")
+
+    def install(self, spec, prefix):
+        env["ONLINE_MAIN"] = prefix
+        for subdir in ["eventlibraries", "pmonitor"]:
+            with working_dir(subdir):
+                autoreconf = Executable("autoreconf")
+                autoreconf("-fvi")
+                configure = Executable("./configure")
+                configure(f"--prefix={prefix}")
+                make()
+                make("install")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds the spack package for sPHENIX/EIC `online_distribution` repository. Supports the ePIC branch as a version named 'ePIC'.

The dependencies are determined from the `configure.ac` files:
- `eventlibraries`: root, boost, lzo, zlib-api, bzip2
- `pmonitor`: root (OFFLINE_MAIN/FROG optional, not modelled)

Sets `ONLINE_MAIN=prefix` so `pmonitor` can find `eventlibraries` at build time. Patches out hardcoded `/opt/local` paths from `eventlibraries/Makefile.am`.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: better rcdaq support)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
