### PR TITLE
dd4hep: display compatibility notice when older geometry is used with Geant4TVUserParticleHandler

### DIFF
--- a/spack_repo/eic/packages/dd4hep/Geant4TVUserParticleHandler_compatibility_notice.patch
+++ b/spack_repo/eic/packages/dd4hep/Geant4TVUserParticleHandler_compatibility_notice.patch
@@ -1,0 +1,12 @@
+diff --git a/DDG4/python/DDSim/Helper/ParticleHandler.py b/DDG4/python/DDSim/Helper/ParticleHandler.py
+--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
++++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
+@@ -156,6 +156,8 @@ class ParticleHandler(ConfigHelper):
+     elif self.userParticleHandler == "Geant4TVUserParticleHandler":
+       if not kernel.detectorDescription().trackingVolume().isValid():
+         logger.error("Geant4TVUserParticleHandler requested but no tracking_volume defined in the XML")
++        logger.error("ePIC users: consider running with a more recent version of the ePIC geometry")
++        logger.error("            or setting --part.userParticleHandler=Geant4TCUserParticleHandler")
+         exit(1)
+ 
+       user = DDG4.Action(kernel, "%s/UserParticleHandler" % self.userParticleHandler)

--- a/spack_repo/eic/packages/dd4hep/package.py
+++ b/spack_repo/eic/packages/dd4hep/package.py
@@ -13,10 +13,7 @@ class Dd4hep(BuiltinDd4hep):
     version("1.32", sha256="8bde4eab9af9841e040447282ea7df3a16e4bcec587c3a1e32f41987da9b1b4d")
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
-    patch(
-        "Geant4TVUserParticleHandler_compatibility_notice.patch",
-        when="@1.30:",
-    )
+    patch("Geant4TVUserParticleHandler_compatibility_notice.patch", when="@1.30:")
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1574.diff?full_index=1",
         sha256="f6e099bcf43c7e711f78fc17e9e4db31afe1a642099e814afb54faf436142357",

--- a/spack_repo/eic/packages/dd4hep/package.py
+++ b/spack_repo/eic/packages/dd4hep/package.py
@@ -14,6 +14,10 @@ class Dd4hep(BuiltinDd4hep):
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
     patch(
+        "Geant4TVUserParticleHandler_compatibility_notice.patch",
+        when="@1.30:",
+    )
+    patch(
         "https://github.com/AIDASoft/DD4hep/pull/1574.diff?full_index=1",
         sha256="f6e099bcf43c7e711f78fc17e9e4db31afe1a642099e814afb54faf436142357",
         when="@=1.35",


### PR DESCRIPTION
This is satelite PR for https://github.com/eic/npsim/pull/44. The issue is that we still ship older geometries (or users might be working on older geometries), that still need to work. There are simple ways to address this, we just need to inform the users about those.