### PR TITLE
npsim: add v1.5.1, add tag eic

### DIFF
--- a/spack_repo/eic/packages/npsim/package.py
+++ b/spack_repo/eic/packages/npsim/package.py
@@ -16,9 +16,12 @@ class Npsim(CMakePackage):
     git = "https://github.com/eic/npsim.git"
     list_url = "https://github.com/eic/npsim/tags"
 
+    tags = ["eic"]
+
     maintainers = ["wdconinc"]
 
     version("main", branch="main")
+    version("1.5.1", sha256="2eaafee95fc0fce0e4f8907eedbe3568829a07bfc716667d7355d905de31c4ce")
     version("1.5.0", sha256="9f9275da048a44ce1480ad63742bc67a8e2629f56bacf4ad993efdc5ab6d9fc6")
     version("1.4.6", sha256="645d6b7791c9d478e081e9da04578e9233f784b692b01bda6ec349871788fb12")
     version("1.4.5", sha256="6d0276872a497cb17da42391e7ceb58f920ca50275a81a7e7216a9b00021b059")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds `npsim` , v1.5.1, which fixes the null pointer dereference that was blocking the DIRC simulations.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Needed to unblock the DIRC simulations.