### PR TITLE
sartre: depends_on c; patch for newer ROOT versions

### DIFF
--- a/spack_repo/eic/packages/sartre/FindROOT-new-version-format.diff
+++ b/spack_repo/eic/packages/sartre/FindROOT-new-version-format.diff
@@ -1,0 +1,23 @@
+--- cmake/modules/FindROOT.cmake        (revision 487)
++++ cmake/modules/FindROOT.cmake        (working copy)
+@@ -62,14 +62,14 @@
+  ENDIF (NOT ROOT_MIN_VERSION)
+    
+  # now parse the parts of the user given version string into variables
+-  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+\\/[0-9][0-9]+" "\\1" req_root_major_vers "${ROOT_MIN_VERSION}")
+-  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+\\/[0-9][0-9]+.*" "\\1" req_root_minor_vers "${ROOT_MIN_VERSION}")
+-  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+)" "\\1" req_root_patch_vers "${ROOT_MIN_VERSION}")
++  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+[\\/.][0-9][0-9]+" "\\1" req_root_major_vers "${ROOT_MIN_VERSION}")
++  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+[\\/.][0-9][0-9]+.*" "\\1" req_root_minor_vers "${ROOT_MIN_VERSION}")
++  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+[\\/.]([0-9][0-9]+)" "\\1" req_root_patch_vers "${ROOT_MIN_VERSION}")
+    
+  # and now the version string given by qmake
+-  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+\\/[0-9][0-9]+.*" "\\1" found_root_major_vers "${ROOTVERSION}")
+-  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+\\/[0-9][0-9]+.*" "\\1" found_root_minor_vers "${ROOTVERSION}")
+-  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+).*" "\\1" found_root_patch_vers "${ROOTVERSION}")
++  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+[\\/.][0-9][0-9]+.*" "\\1" found_root_major_vers "${ROOTVERSION}")
++  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+[\\/.][0-9][0-9]+.*" "\\1" found_root_minor_vers "${ROOTVERSION}")
++  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+[\\/.]([0-9][0-9]+).*" "\\1" found_root_patch_vers "${ROOTVERSION}")
+ 
+  IF (found_root_major_vers LESS 5)
+    MESSAGE( FATAL_ERROR "Invalid ROOT version \"${ROOTERSION}\", at least major version 4 is required, e.g. \"5.00/00\"")

--- a/spack_repo/eic/packages/sartre/FindROOT-new-version-format.diff
+++ b/spack_repo/eic/packages/sartre/FindROOT-new-version-format.diff
@@ -1,9 +1,9 @@
 --- cmake/modules/FindROOT.cmake        (revision 487)
 +++ cmake/modules/FindROOT.cmake        (working copy)
 @@ -62,14 +62,14 @@
-  ENDIF (NOT ROOT_MIN_VERSION)
+   ENDIF (NOT ROOT_MIN_VERSION)
     
-  # now parse the parts of the user given version string into variables
+   # now parse the parts of the user given version string into variables
 -  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+\\/[0-9][0-9]+" "\\1" req_root_major_vers "${ROOT_MIN_VERSION}")
 -  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+\\/[0-9][0-9]+.*" "\\1" req_root_minor_vers "${ROOT_MIN_VERSION}")
 -  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+)" "\\1" req_root_patch_vers "${ROOT_MIN_VERSION}")
@@ -11,7 +11,7 @@
 +  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+[\\/.][0-9][0-9]+.*" "\\1" req_root_minor_vers "${ROOT_MIN_VERSION}")
 +  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+[\\/.]([0-9][0-9]+)" "\\1" req_root_patch_vers "${ROOT_MIN_VERSION}")
     
-  # and now the version string given by qmake
+   # and now the version string given by qmake
 -  STRING(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+\\/[0-9][0-9]+.*" "\\1" found_root_major_vers "${ROOTVERSION}")
 -  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+\\/[0-9][0-9]+.*" "\\1" found_root_minor_vers "${ROOTVERSION}")
 -  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+).*" "\\1" found_root_patch_vers "${ROOTVERSION}")
@@ -19,5 +19,5 @@
 +  STRING(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+[\\/.][0-9][0-9]+.*" "\\1" found_root_minor_vers "${ROOTVERSION}")
 +  STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+[\\/.]([0-9][0-9]+).*" "\\1" found_root_patch_vers "${ROOTVERSION}")
  
-  IF (found_root_major_vers LESS 5)
-    MESSAGE( FATAL_ERROR "Invalid ROOT version \"${ROOTERSION}\", at least major version 4 is required, e.g. \"5.00/00\"")
+   IF (found_root_major_vers LESS 5)
+     MESSAGE( FATAL_ERROR "Invalid ROOT version \"${ROOTERSION}\", at least major version 4 is required, e.g. \"5.00/00\"")

--- a/spack_repo/eic/packages/sartre/add-cmath-headers.diff
+++ b/spack_repo/eic/packages/sartre/add-cmath-headers.diff
@@ -1,0 +1,40 @@
+--- a/src/Amplitudes.cpp
++++ b/src/Amplitudes.cpp
+@@ -23,6 +23,7 @@
+ //#define SARTRE_IN_MULTITHREADED_MODE 1  
+ #include <iostream>  
+ #include <cstdio>  
++#include <cmath>  
+ #include "Amplitudes.h"  
+ #include "Constants.h"  
+ #include "TableGeneratorSettings.h"  
+--- a/src/ModeFinderFunctor.cpp
++++ b/src/ModeFinderFunctor.cpp
+@@ -24,6 +24,7 @@
+ #include "CrossSection.h"    
+ #include "Kinematics.h"    
+ #include <iostream>
++#include <cmath>
+ 
+ using namespace std;    
+ 
+--- a/src/Settings.cpp
++++ b/src/Settings.cpp
+@@ -29,6 +29,7 @@
+ #include "TParticlePDG.h"
+ #include "TError.h"
+ #include <cstdlib>  
++#include <cmath>
+ 
+ #define PR(x) cout << #x << " = " << (x) << endl;
+ 
+--- a/src/VectorMesonDecayMass.cpp
++++ b/src/VectorMesonDecayMass.cpp
+@@ -23,6 +23,7 @@
+ #include "VectorMesonDecayMass.h"
+ #include "EventGeneratorSettings.h"
+ #include <iostream>
++#include <cmath>
+ 
+ using namespace std;
+ 

--- a/spack_repo/eic/packages/sartre/package.py
+++ b/spack_repo/eic/packages/sartre/package.py
@@ -21,6 +21,7 @@ class Sartre(CMakePackage):
 
     version("1.39", sha256="82ed77243bea61bb9335f705c4b132f0b53d0de17c26b89389fa9cd3adcef44d")
 
+    patch("add-cmath-headers.diff‎")
     patch("FindROOT-new-version-format.diff", level=0, when="^root@6.30:")
 
     parallel = False

--- a/spack_repo/eic/packages/sartre/package.py
+++ b/spack_repo/eic/packages/sartre/package.py
@@ -23,6 +23,7 @@ class Sartre(CMakePackage):
 
     parallel = False
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("gsl")

--- a/spack_repo/eic/packages/sartre/package.py
+++ b/spack_repo/eic/packages/sartre/package.py
@@ -21,6 +21,8 @@ class Sartre(CMakePackage):
 
     version("1.39", sha256="82ed77243bea61bb9335f705c4b132f0b53d0de17c26b89389fa9cd3adcef44d")
 
+    patch("FindROOT-new-version-format.diff", level=0, when="^root@6.30:")
+
     parallel = False
 
     depends_on("c", type="build")

--- a/spack_repo/eic/packages/sartre/package.py
+++ b/spack_repo/eic/packages/sartre/package.py
@@ -21,7 +21,7 @@ class Sartre(CMakePackage):
 
     version("1.39", sha256="82ed77243bea61bb9335f705c4b132f0b53d0de17c26b89389fa9cd3adcef44d")
 
-    patch("add-cmath-headers.diff‎")
+    patch("add-cmath-headers.diff")
     patch("FindROOT-new-version-format.diff", level=0, when="^root@6.30:")
 
     parallel = False


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds to `sartre` the dependency on a C compiler since the project(Sartre) in their CMakeLists.txt defaults to C and CXX for LANGUAGES.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/25579573295/job/75169951056?pr=904)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
