### PR TITLE
pyrobird: limit setuptools to :76 due to project.license

### DIFF
--- a/spack_repo/eic/packages/pyrobird/package.py
+++ b/spack_repo/eic/packages/pyrobird/package.py
@@ -34,7 +34,7 @@ class Pyrobird(PythonPackage):
     variant("xrootd", default=False, description="Enable XRootD functionality")
 
     with when("@0.2:"):
-        depends_on("py-setuptools@61:", type="build")
+        depends_on("py-setuptools@61:76", type="build")
         depends_on("py-wheel", type="build")
     with when("@0.1"):
         depends_on("py-hatchling", type="build")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Since `pyrobird` uses the deprecated project.license in pyproject.toml, we should restrict setuptools to at most 76.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/25579573295/job/75169951134?pr=904#step:13:410)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
