### PR TITLE
fix(ci): use setup-spack with correct parameter name

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Spack
         uses: spack/setup-spack@v3
         with:
-          ref: develop
+          spack_ref: develop
 
       - name: Add package repositories
         run: |
@@ -236,7 +236,7 @@ jobs:
       - name: Setup Spack
         uses: spack/setup-spack@v3
         with:
-          ref: develop
+          spack_ref: develop
 
       - name: Add package repositories
         run: |

--- a/.github/workflows/style_and_audit.yml
+++ b/.github/workflows/style_and_audit.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Spack
         uses: spack/setup-spack@v3
         with:
-          ref: develop
+          spack_ref: develop
 
       - name: Configure ruff for package repository
         run: |


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the (non-existent) `ref` parameter for the setup-spack action.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: warning on every run)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
