### PR TITLE
fix: prevent GLIBCXX mismatch by pinning gcc-runtime ≥ 13 and excluding it from cache reuse

### DIFF
--- a/config/ci/concretizer.yaml
+++ b/config/ci/concretizer.yaml
@@ -2,3 +2,9 @@ concretizer:
   reuse:
     roots: false
     dependencies: true
+    exclude:
+      # Do not reuse gcc-runtime from the build cache: stale entries (e.g.
+      # gcc-runtime-10.x for linux-x86_64_v3) cause GLIBCXX version mismatches
+      # when packages built for x86_64_v4 with modern C++20 code (node-js/V8,
+      # abseil) require symbols only available in GCC >= 12/13.
+      - gcc-runtime

--- a/config/ci/packages.yaml
+++ b/config/ci/packages.yaml
@@ -1,4 +1,11 @@
 packages:
+  # Require GCC >= 13 runtime to ensure GLIBCXX_3.4.32 (needed by node-js 24/V8
+  # and other modern C++20 packages). Without this, the concretizer reuses a
+  # stale gcc-runtime-10.x from the build cache (which only provides
+  # GLIBCXX <= 3.4.30), causing link-time failures at package build time.
+  gcc-runtime:
+    require:
+      - "@13:"
   gl:
     require:
       - glx


### PR DESCRIPTION
## Problem

When building packages like `node-js-24` (which embeds V8 and Abseil using C++20 features), the CI fails with:

```
bytecode_builtins_list_generator: .../gcc-runtime-10.5.0/lib/libstdc++.so.6: version `GLIBCXX_3.4.31' not found
bytecode_builtins_list_generator: .../gcc-runtime-10.5.0/lib/libstdc++.so.6: version `GLIBCXX_3.4.32' not found
```

Example: https://github.com/eic/eic-spack/actions/runs/25579573295/job/75169951129

## Root Cause

Two compounding factors:

1. **GCC version too old** – `gcc-runtime-10.5.0` only provides `GLIBCXX` symbols up to `3.4.30`. Node-js 24 / V8 requires `GLIBCXX_3.4.31` (GCC 12.1) and `GLIBCXX_3.4.32` (GCC 13.1) for C++20 standard-library features.

2. **Microarchitecture mismatch** – `concretizer.reuse.dependencies: true` causes Spack to reuse a `gcc-runtime-10.5.0` entry built for `linux-x86_64_v3` even when the top-level package targets `linux-x86_64_v4`. The wrong `libstdc++.so.6` ends up in `LD_LIBRARY_PATH` at build time.

## Fix

**`config/ci/packages.yaml`** – Require `gcc-runtime@13:` so the concretizer always selects a GCC 13+ runtime that provides `GLIBCXX_3.4.32`.

**`config/ci/concretizer.yaml`** – Exclude `gcc-runtime` from build-cache reuse so the version constraint above cannot be overridden by a stale cached entry.
