### PR TITLE
eic-opticks: disable tests for 0.4.0

### DIFF
--- a/spack_repo/eic/packages/eic_opticks/package.py
+++ b/spack_repo/eic/packages/eic_opticks/package.py
@@ -50,7 +50,5 @@ class EicOpticks(CMakePackage, CudaPackage):
             env.append_flags("CPPFLAGS", "-DGLM_ENABLE_EXPERIMENTAL")
 
     def cmake_args(self):
-        args = [
-            self.define("BUILD_TESTING", self.spec.satisfies("@0.5:") and self.run_tests),
-        ]
+        args = [self.define("BUILD_TESTING", self.spec.satisfies("@0.5:") and self.run_tests)]
         return args

--- a/spack_repo/eic/packages/eic_opticks/package.py
+++ b/spack_repo/eic/packages/eic_opticks/package.py
@@ -48,3 +48,9 @@ class EicOpticks(CMakePackage, CudaPackage):
         # dual_quaternion, which are reached via string_cast in this codebase.
         if self.spec.satisfies("^glm@0.9.9:"):
             env.append_flags("CPPFLAGS", "-DGLM_ENABLE_EXPERIMENTAL")
+
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_TESTING", self.spec.satisfies("@0.5:") and self.run_tests),
+        ]
+        return args


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
The CI build of EIC-Opticks fails in the testing phase, https://github.com/eic/eic-spack/actions/runs/25579573295/job/75169956092. This PR disables testing up to the current version.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/25579573295/job/75169956092)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
