### PR TITLE
fix for code scanning alert: workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-new-versions.yaml
+++ b/.github/workflows/check-new-versions.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 13 * * 1" # Every Monday at 1PM UTC (9AM EST)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-new-versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eic/eic-spack/security/code-scanning/4](https://github.com/eic/eic-spack/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/check-new-versions.yaml` so token scope is documented and least-privilege by default.  
Best fix here: set workflow-level permissions to the minimum needed by all jobs in this workflow:
- `contents: write` (required for creating commits/branches via create-pull-request)
- `pull-requests: write` (required for opening/updating PRs)

Place this block near the top-level keys (after `on:` and before `jobs:`) to apply consistently to the job shown, without changing existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
