### PR TITLE
online-distribution: HAVE_GETOPT_H

### DIFF
--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -44,7 +44,7 @@ class OnlineDistribution(Package):
                 autoreconf("-fvi")
                 configure = Executable("./configure")
                 configure(f"--prefix={prefix}")
-                make("CPPFLAGS=-DHAVE_GETOPT_H=1")
+                make("CPPFLAGS=-DLinux -DHAVE_GETOPT_H=1")
                 make("install")
 
     def setup_run_environment(self, env):

--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -44,7 +44,7 @@ class OnlineDistribution(Package):
                 autoreconf("-fvi")
                 configure = Executable("./configure")
                 configure(f"--prefix={prefix}")
-                make("HAVE_GETOPT_H=1")
+                make("CPPFLAGS=-DHAVE_GETOPT_H=1")
                 make("install")
 
     def setup_run_environment(self, env):

--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -44,7 +44,7 @@ class OnlineDistribution(Package):
                 autoreconf("-fvi")
                 configure = Executable("./configure")
                 configure(f"--prefix={prefix}")
-                make()
+                make("HAVE_GETOPT=1")
                 make("install")
 
     def setup_run_environment(self, env):

--- a/spack_repo/eic/packages/online_distribution/package.py
+++ b/spack_repo/eic/packages/online_distribution/package.py
@@ -44,7 +44,7 @@ class OnlineDistribution(Package):
                 autoreconf("-fvi")
                 configure = Executable("./configure")
                 configure(f"--prefix={prefix}")
-                make("HAVE_GETOPT=1")
+                make("HAVE_GETOPT_H=1")
                 make("install")
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR works around an incomplete include guard in `online-distribution`. The include is guarded but the use isn't. So best to make getopt a dependency.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fails to install)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
