### PR TITLE
ci: make buildcache index update non-fatal

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -189,6 +189,7 @@ jobs:
             (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
           )
+        continue-on-error: true
         run: |
           unset SPACK_DISABLE_LOCAL_CONFIG
           spack buildcache update-index github-actions
@@ -303,6 +304,7 @@ jobs:
             (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
           )
+        continue-on-error: true
         run: |
           unset SPACK_DISABLE_LOCAL_CONFIG
           spack buildcache update-index github-actions


### PR DESCRIPTION
The `spack buildcache update-index` step can fail with transient errors such as `503: Egress is over the account limit.` which are unrelated to the actual build result. Add `continue-on-error: true` to both **Update buildcache index** steps (in the `build-environment` and `build-packages` jobs) so these infrastructure hiccups do not mark an otherwise successful build as failed.

Fixes the failure seen at https://github.com/eic/eic-spack/actions/runs/25825838204/job/75878671152?pr=917#step:15:94