### PR TITLE
fix(ci): run check-new-versions in spack-noble:develop

### DIFF
--- a/.github/workflows/check-new-versions.yaml
+++ b/.github/workflows/check-new-versions.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-new-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/spack/ubuntu-jammy:latest
+    container: ghcr.io/spack/ubuntu-noble:develop
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR modifies the check-new-versions workflow to run in a newer container: ubuntu 24.04 with current spack develop branch. This should get our auto version update PRs to get started again.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/25870876454/job/76025468907#step:5:222)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
