### PR TITLE
fix(ci): fail check-new-versions when issue happen

### DIFF
--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -Euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+IFS=$'\n\t'
 
 package_list=$(spack tags eic)
 

--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Euo pipefail
+set -Eeuo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 IFS=$'\n\t'
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the issue that failures in the check-new-versions workflow are not causing workflow failures (as they should).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/25870876454/job/76025468907#step:5:222)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
