### PR TITLE
dd4hep: add v1.36-mt.1 and v1.37-mt.1

### DIFF
--- a/spack_repo/eic/packages/dd4hep/package.py
+++ b/spack_repo/eic/packages/dd4hep/package.py
@@ -9,10 +9,20 @@ except ImportError:
 class Dd4hep(BuiltinDd4hep):
     __doc__ = BuiltinDd4hep.__doc__
 
-    version("1.32.1", sha256="f47fbede967b609e142c3116d23b4993f9d57fbae28a1739b5333503bc498883")
-    version("1.32", sha256="8bde4eab9af9841e040447282ea7df3a16e4bcec587c3a1e32f41987da9b1b4d")
+    version(
+        "1.37.mt.1",
+        sha256="b9c4d8fd0221671976ba308a69fd499ef5f37d8bb8e525616b1da7534e652a51",
+        url="https://github.com/eic/DD4hep/archive/refs/tags/v01-37-mt.1.tar.gz",
+    )
+    version(
+        "1.36.mt.1",
+        sha256="2f26b8c58f27028d9450e5377cc18840526f9936b83ec2c4051214480da6df9b",
+        url="https://github.com/eic/DD4hep/archive/refs/tags/v01-36-mt.1.tar.gz",
+    )
+
     variant("frames", default=True, description="Use podio frames", when="@1.25.1")
     variant("frames", default=True, description="Use podio frames", when="@1.24")
+
     patch("Geant4TVUserParticleHandler_compatibility_notice.patch", when="@1.30:")
     patch(
         "https://github.com/AIDASoft/DD4hep/pull/1574.diff?full_index=1",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds two snapshot tags on the eic/DD4hep fork backport branches v1.36-mt and v1.37-mt where the current status of the wdconinc/DD4hep fork ddsim-mt branch is maintained for testing at scale.

Also removed two old versions that are in the main repo by now.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: DD4hep multithreaded for running benchmarks against)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
