### PR TITLE
acts: backport various fixes for Gen3 in v45.2.0

### DIFF
--- a/spack_repo/eic/packages/acts/package.py
+++ b/spack_repo/eic/packages/acts/package.py
@@ -32,6 +32,12 @@ class Acts(BuiltinActs):
         sha256="3238f9c162a50c0579f2bd45fd242b36e8fd28b59c23ace7fa429f741a5cc84b",
         when="@45.2:45",
     )
+    # SurfaceArrayNavigationPolicy explicit destructor for incomplete-type fix (landed in v45.4)
+    patch(
+        "https://github.com/acts-project/acts/pull/5192.patch?full_index=1",
+        sha256="36726a66e3186ce26b8897e4db73901352c6f590787e54cf9d48848a3dfac204",
+        when="@45.2:45.3",
+    )
 
     # Use template<holder_t> for PodioTrack(State)Container
     patch(

--- a/spack_repo/eic/packages/acts/package.py
+++ b/spack_repo/eic/packages/acts/package.py
@@ -26,6 +26,12 @@ class Acts(BuiltinActs):
         sha256="bee084dd48b596312642c4c815d183c018b4a37735bc8f331a7b8cb3f50a269c",
         when="@45.2:46.2",
     )
+    # ExtentEnvelope::set() chain method, required by PR #5193 (landed in v46.0)
+    patch(
+        "https://github.com/acts-project/acts/pull/5244.patch?full_index=1",
+        sha256="3238f9c162a50c0579f2bd45fd242b36e8fd28b59c23ace7fa429f741a5cc84b",
+        when="@45.2:45",
+    )
 
     # Use template<holder_t> for PodioTrack(State)Container
     patch(


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR backports a few small `acts` PRs (https://github.com/acts-project/acts/pull/5244, https://github.com/acts-project/acts/pull/5192) to v45.2, needed to fix https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7853983#L287 and https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7855187#L430. They apply cleanly to 45.2.0. Passed over in local testing. 

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7853983#L287, https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7855187#L430)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
