### PR TITLE
root: fix cling CMake include ordering for external LLVM

### DIFF
--- a/spack_repo/eic/packages/root/cling-cmake-external-llvm-include-order.patch
+++ b/spack_repo/eic/packages/root/cling-cmake-external-llvm-include-order.patch
@@ -1,0 +1,15 @@
+--- a/interpreter/cling/CMakeLists.txt
++++ b/interpreter/cling/CMakeLists.txt
+@@ -284,7 +284,11 @@ endmacro()
+ endif()
+ endmacro()
+ 
+-include_directories(BEFORE SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
++if(builtin_llvm)
++  include_directories(BEFORE SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
++else()
++  include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
++endif()
+ 
+ macro(add_cling_library name)
+   cmake_parse_arguments(ARG

--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -13,6 +13,13 @@ class Root(BuiltinRoot):
     version("6.32.12", sha256="2e41968aeb0406ee31c30af9c046143099b251846e0839cb04f4e960c7893e19")
     version("6.32.10", sha256="5a896804ec153685e8561adaa4e546b708139c484280aa6713a0a178f5b7f98b")
 
+    # [cling] Guard BEFORE in include_directories for external LLVM to avoid
+    # cxxabi.h conflict between LLVM libc++abi and GCC runtime headers
+    patch(
+        "cling-cmake-external-llvm-include-order.patch",
+        sha256="f81e01aff35141cbbf1f34864c87dc570b410425a3bcc19b4ce53e6c1de78132",
+        when="@6.36: ~builtin_llvm",
+    )
     # [metacling] Add missing lock to TCling::Evaluate
     patch(
         "https://github.com/root-project/root/pull/18943.patch?full_index=1",


### PR DESCRIPTION
## Problem

When building ROOT against an external (system-installed) LLVM (`~builtin_llvm`), the `LLVM_INCLUDE_DIRS` path (e.g. `/usr/lib/llvm-20/include`) contains a `cxxabi.h` from libc++abi.

The unconditional line in `interpreter/cling/CMakeLists.txt`:
```cmake
include_directories(BEFORE SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
```
pushes that directory in front of all system includes, causing LLVM's `cxxabi.h` to shadow GCC 14's `cxxabi_init_exception.h`. This triggers a hard compiler error on `__cxa_init_primary_exception`: LLVM declares it returning `__cxa_exception*`, while GCC 14 declares it returning `__cxa_refcounted_exception*`.

## Root cause

The `BEFORE` flag was introduced (commit `3c58e0d3`, 2020) to ensure cling's own LLVM headers take priority. This is correct for `builtin_llvm=ON` — the in-tree `LLVM_INCLUDE_DIRS` contains no `cxxabi.h`. For external LLVM, `BEFORE` is not needed (the headers are already registered by `interpreter/CMakeLists.txt` without `BEFORE`) and actively harmful.

## Fix

Guard the `BEFORE` flag with `if(builtin_llvm)`. For external LLVM, use plain `SYSTEM` (still suppresses warnings) without `BEFORE`.

Fixes: https://github.com/eic/containers/pull/288