### PR TITLE
fix: prevent failing versions from blocking auto-checksumming

### DIFF
--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -18,12 +18,14 @@ for p in ${package_list}; do
     continue
   fi
 
-  # Read one version per array element; drop pre/rc/alpha/beta
+  # Read one version per array element; strip leading whitespace, drop pre/rc/alpha/beta
   mapfile -t versions < <((spack versions --new $p || true) \
+    | sed 's/^[[:space:]]*//' \
     | grep -Ev '(rc|pre|alpha|beta)' \
     || true)
 
   if [[ ${#versions[@]} -gt 0 ]]; then
     spack checksum --add-to-package --batch $p "${versions[@]}"
+    sed -i 's/[[:space:]]*# FIXME$//' "$(spack location -p $p)/package.py"
   fi
 done

--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -18,7 +18,7 @@ for p in ${package_list}; do
     continue
   fi
 
-  v=$(spack versions --new $p)
+  v=$(spack versions --new $p || true)
   # ignore pre and rc versions (for all packages)
   v=$(echo $v | sed 's/\S*\(rc\|pre\|alpha\|beta\)\S*//g')
   # using `echo $v` instead of "$v" will handle v=" " correctly

--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 IFS=$'\n\t'
 
-package_list=$(spack tags eic)
+package_list=$(spack tags eic | sed 's/^[[:space:]]*//')
 
 # prune duplicates (needed if package list is appended to)
 #package_list=$(echo ${package_list} | tr ' ' '\n' | sort | uniq | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')

--- a/.github/scripts/checksum_new_versions.sh
+++ b/.github/scripts/checksum_new_versions.sh
@@ -18,12 +18,12 @@ for p in ${package_list}; do
     continue
   fi
 
-  v=$(spack versions --new $p || true)
-  # ignore pre and rc versions (for all packages)
-  v=$(echo $v | sed 's/\S*\(rc\|pre\|alpha\|beta\)\S*//g')
-  # using `echo $v` instead of "$v" will handle v=" " correctly
+  # Read one version per array element; drop pre/rc/alpha/beta
+  mapfile -t versions < <((spack versions --new $p || true) \
+    | grep -Ev '(rc|pre|alpha|beta)' \
+    || true)
 
-  if [[ ! -z `echo $v` ]]; then
-    spack checksum --add-to-package --batch $p $v
+  if [[ ${#versions[@]} -gt 0 ]]; then
+    spack checksum --add-to-package --batch $p "${versions[@]}"
   fi
 done


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request makes a small but important change to the `.github/scripts/checksum_new_versions.sh` script to improve its robustness when checking for new package versions.

* The command that fetches new versions with `spack versions --new $p` is now allowed to fail without stopping the script, by appending `|| true`. This prevents the script from exiting if `spack` fails for a package.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: a missing version in `bmf` fails the script entirely)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI for PR description.