### PR TITLE
npsim: add v1.5.2

### DIFF
--- a/spack_repo/eic/packages/npsim/package.py
+++ b/spack_repo/eic/packages/npsim/package.py
@@ -21,6 +21,7 @@ class Npsim(CMakePackage):
     maintainers = ["wdconinc"]
 
     version("main", branch="main")
+    version("1.5.2", sha256="7f21713e47e35631e0a859838236c8923f589b49f19530733bd06eb214358cc9")
     version("1.5.1", sha256="2eaafee95fc0fce0e4f8907eedbe3568829a07bfc716667d7355d905de31c4ce")
     version("1.5.0", sha256="9f9275da048a44ce1480ad63742bc67a8e2629f56bacf4ad993efdc5ab6d9fc6")
     version("1.4.7", sha256="6235742e7b27ed7b6f8ed4f8ff8b5e6ff779e06eed4951975c6557cf9207c62e")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds npsim-1.5.2, which reverts the tracking region handler (deferred until smarter), fixes a few geocad bugs, and adds npdet_to_dot.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
