### PR TITLE
jana2: disable unit tests up to 2026.02.00

### DIFF
--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -122,6 +122,10 @@ class Jana2(CMakePackage, CudaPackage):
 
         return args
 
+    @when("@:2026.02.00")
+    def check(self):
+        pass
+
     def setup_run_environment(self, env):
         env.append_path("JANA_PLUGIN_PATH", self.prefix.lib.JANA.plugins)
         env.set("JANA_HOME", self.prefix)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR disables unit testing (i.e. always pass) for `jana2` since they do not pass in the spack ordering (cmake, build, test, install) and are mostly post-install tests. PRs have been filed, so this is marked as only affecting up to the currently released version.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: auto-builds in CI fail for jana2)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
