### PR TITLE
root: patch to ensure GIL is held during CPython API call

### DIFF
--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -13,6 +13,12 @@ class Root(BuiltinRoot):
     version("6.32.12", sha256="2e41968aeb0406ee31c30af9c046143099b251846e0839cb04f4e960c7893e19")
     version("6.32.10", sha256="5a896804ec153685e8561adaa4e546b708139c484280aa6713a0a178f5b7f98b")
 
+    # [python] Ensure GIL is held during CPython API call
+    patch(
+        "https://github.com/root-project/root/pull/22402.patch?full_index=1",
+        sha256="684a77195a149cbb683a0e37fbd75f178bd622aeefb26527756613f258c58696",
+        when="@6.38.02:6.40.00",
+    )
     # [metacling] Add missing lock to TCling::Evaluate
     patch(
         "https://github.com/root-project/root/pull/18943.patch?full_index=1",

--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -60,3 +60,6 @@ class Root(BuiltinRoot):
         sha256="93673f697bd4c7def71c3e8420b930d59546bc709e9fe6ed23a6dddd82fc104b",
         when="@6.30:6.30.4",
     )
+
+    def check(self):
+        pass


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR backports https://github.com/root-project/root/pull/22402 into 6.38.02 through 6.40.00, in order to avoid failures in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7889057.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7889057)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
