### PR TITLE
jana2: backport perfetto

### DIFF
--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -43,6 +43,7 @@ class Jana2(CMakePackage, CudaPackage):
     version("2.2.1-rc1", sha256="7b65ce967d9c0690e22f4450733ead4acebf8fa510f792e0e4a6def14fb739b1")
     version("2.2.0", sha256="60940e182593dafddaa76d582d3270ac47694fa3f20257493e1017b34f624ba9")
 
+    variant("perfetto", default=False, description="Include Perfetto tracing.", when="@2026.02.00:")
     variant("podio", default=False, description="Build with PODIO support.")
     variant("python", default=True, description="Build with Python bindings.")
     variant("root", default=False, description="Use ROOT for janarate.")
@@ -63,6 +64,12 @@ class Jana2(CMakePackage, CudaPackage):
         depends_on("py-jinja2")
         depends_on("py-pyyaml")
 
+    # Add Perfetto performance tracing support
+    patch(
+        "https://github.com/JeffersonLab/JANA2/commit/28d1ea76b4e9c48c3008e08b359d1cbe8a3bf08b.patch?full_index=1",
+        sha256="",
+        when="@2026.02.00",
+    )
     # Add LinkDef.h for janaview and data model example add
     patch(
         "https://github.com/JeffersonLab/JANA2/commit/490fd69174a6241b5e532f346dbc1d05b830419f.patch?full_index=1",
@@ -104,6 +111,7 @@ class Jana2(CMakePackage, CudaPackage):
             self.define_from_variant("USE_ROOT", "root"),
             self.define_from_variant("USE_ZEROMQ", "zmq"),
             self.define_from_variant("USE_PYTHON", "python"),
+            self.define_from_variant("USE_PERFETTO", "perfetto"),
             self.define("BUILD_EXAMPLES", self.run_tests),
             self.define("BUILD_TESTS", self.run_tests),
         ]

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -67,7 +67,7 @@ class Jana2(CMakePackage, CudaPackage):
     # Add Perfetto performance tracing support
     patch(
         "https://github.com/JeffersonLab/JANA2/commit/28d1ea76b4e9c48c3008e08b359d1cbe8a3bf08b.patch?full_index=1",
-        sha256="",
+        sha256="a0fa5e04c4f5c58091c11b0f4dc8b54054ee4d69f275c063cec631495c5a2256",
         when="@2026.02.00",
     )
     # Add LinkDef.h for janaview and data model example add

--- a/spack_repo/eic/packages/jana2/package.py
+++ b/spack_repo/eic/packages/jana2/package.py
@@ -43,7 +43,9 @@ class Jana2(CMakePackage, CudaPackage):
     version("2.2.1-rc1", sha256="7b65ce967d9c0690e22f4450733ead4acebf8fa510f792e0e4a6def14fb739b1")
     version("2.2.0", sha256="60940e182593dafddaa76d582d3270ac47694fa3f20257493e1017b34f624ba9")
 
-    variant("perfetto", default=False, description="Include Perfetto tracing.", when="@2026.02.00:")
+    variant(
+        "perfetto", default=False, description="Include Perfetto tracing.", when="@2026.02.00:"
+    )
     variant("podio", default=False, description="Build with PODIO support.")
     variant("python", default=True, description="Build with Python bindings.")
     variant("root", default=False, description="Use ROOT for janarate.")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR backports the JANA2 perfetto functionality to 2026.02.00. Screenshot in https://github.com/JeffersonLab/JANA2/pull/497.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: backport perfetto)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
