### PR TITLE
root: patch for tessellated closure checks after initialization

### DIFF
--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -18,6 +18,7 @@ class Root(BuiltinRoot):
         "https://github.com/root-project/root/pull/22457.patch?full_index=1",
         sha256="67b953213449b57df76ccce374dad4d4e9f3b5158f6c5241c974cd4f0f6b0d47",
         when="@6.40.00",
+    )
     # [python] Ensure GIL is held during CPython API call
     patch(
         "https://github.com/root-project/root/pull/22402.patch?full_index=1",

--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -13,6 +13,12 @@ class Root(BuiltinRoot):
     version("6.32.12", sha256="2e41968aeb0406ee31c30af9c046143099b251846e0839cb04f4e960c7893e19")
     version("6.32.10", sha256="5a896804ec153685e8561adaa4e546b708139c484280aa6713a0a178f5b7f98b")
 
+    # [geom] Fix tessellated closure checks after initialization
+    patch(
+        "https://github.com/root-project/root/commit/d4435369043bbd45a30c10a3ee25e1d4df316b5f.patch?full_index=1",
+        sha256="67b953213449b57df76ccce374dad4d4e9f3b5158f6c5241c974cd4f0f6b0d47",
+        when="@6.40.00",
+    )
     # [metacling] Add missing lock to TCling::Evaluate
     patch(
         "https://github.com/root-project/root/pull/18943.patch?full_index=1",

--- a/spack_repo/eic/packages/root/package.py
+++ b/spack_repo/eic/packages/root/package.py
@@ -15,7 +15,7 @@ class Root(BuiltinRoot):
 
     # [geom] Fix tessellated closure checks after initialization
     patch(
-        "https://github.com/root-project/root/commit/d4435369043bbd45a30c10a3ee25e1d4df316b5f.patch?full_index=1",
+        "https://github.com/root-project/root/pull/22457.patch?full_index=1",
         sha256="67b953213449b57df76ccce374dad4d4e9f3b5158f6c5241c974cd4f0f6b0d47",
         when="@6.40.00",
     # [python] Ensure GIL is held during CPython API call


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR backports https://github.com/root-project/root/pull/22457 to ROOT 6.40.00 to fix our use of tessellated solids in the BHCal (https://github.com/eic/containers/actions/runs/26316798957/job/77483990403?pr=298).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/containers/actions/runs/26316798957/job/77483990403?pr=298)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
