### PR TITLE
fix(ci): verify checksums with a checkout by sha, not ref

### DIFF
--- a/.github/workflows/style_and_audit.yml
+++ b/.github/workflows/style_and_audit.yml
@@ -61,8 +61,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/eic-spack
           # Ensure the PR base commit exists locally (PRs can come from forks).
           git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
-          git fetch --no-tags --prune upstream ${{ github.event.pull_request.base.ref }}
+          git fetch --no-tags --prune --depth=1 upstream ${{ github.event.pull_request.base.sha }}
           spack ci verify-versions ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+
       - name: Check and fix package style
         id: style-check
         run: |


### PR DESCRIPTION
Change git fetch command to use base commit SHA for depth.

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes https://github.com/eic/eic-spack/actions/runs/27146011445/job/80123843094?pr=950 by changing the git fetch command to use base commit SHA instead of ref.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/eic-spack/actions/runs/27146011445/job/80123843094?pr=950)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
