### PR TITLE
pyrobird: yank 0.2.7

### DIFF
--- a/spack_repo/eic/packages/pyrobird/package.py
+++ b/spack_repo/eic/packages/pyrobird/package.py
@@ -21,7 +21,8 @@ class Pyrobird(PythonPackage):
 
     license("LGPL-3.0-or-later", checked_by="wdconinc")
 
-    version("0.2.7", sha256="907fe4db5b4b3ec84fbf05544957d5d4f26df5ceb99b0aa46f91eb3ee55948ad")
+    # 0.2.7 is broken on pypi; https://pypi.org/project/pyrobird/0.2.7/#files 37.7 kb
+    #version("0.2.7", sha256="907fe4db5b4b3ec84fbf05544957d5d4f26df5ceb99b0aa46f91eb3ee55948ad")
     version("0.2.6", sha256="aecdfbdcf21260cfa3db3b1350a08277a83097508a9d5f406aff61a0748c97ff")
     version("0.2.4", sha256="e75a4d20e4c35f30d6a60ce70a64872ade8cccddf7930cb5cca771b1d8f6da1d")
     version("0.2.3", sha256="94115a4180a46fc0c4660c7d74c138bac32b217ebafdbff5941311d038a7e98d")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Pyrobird v0.2.7 on pypi https://pypi.org/project/pyrobird/0.2.7/#files lists an archive of 37.7 kb, not 76 MB as for 0.2.6.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Pyrobird in eic-shell currently broken.