### PR TITLE
fix(ci): don't limit fetch depth in version checksum

### DIFF
--- a/.github/workflows/style_and_audit.yml
+++ b/.github/workflows/style_and_audit.yml
@@ -61,7 +61,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/eic-spack
           # Ensure the PR base commit exists locally (PRs can come from forks).
           git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
-          git fetch --no-tags --prune --depth=1 upstream ${{ github.event.pull_request.base.sha }}
+          git fetch --no-tags --prune upstream ${{ github.event.pull_request.base.sha }}
           spack ci verify-versions ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
 
       - name: Check and fix package style


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR should fix the failing style and audit tests due to the missing sha. Instead of using a fetch depth of 1 we now fetch the full history. The size of this repository is smaller enough that performance impact is acceptable.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

High priority since it fixes broken CI checks.