### PR TITLE
fix: guard imports of spack.llnl to allow for refactor upstream

### DIFF
--- a/.github/scripts/verify_checksums.py
+++ b/.github/scripts/verify_checksums.py
@@ -13,8 +13,14 @@ import sys
 
 import spack.ci as spack_ci
 import spack.cmd.ci as ci_cmd
-import spack.llnl.util.filesystem as fs
-import spack.llnl.util.tty as tty
+try:
+    import spack.util.filesystem as fs
+except ImportError:
+    import spack.llnl.util.filesystem as fs
+try:
+    import spack.util.tty as tty
+except ImportError:
+    import spack.llnl.util.tty as tty
 import spack.repo
 import spack.spec
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This extends #962 with the fixes to allow for the ongoing deprecation of the spack.llnl namespace.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Fixes currently broken script.