### PR TITLE
fix: rm references to llnl in imports of spack util

### DIFF
--- a/spack_repo/eic/packages/k4actstracking/package.py
+++ b/spack_repo/eic/packages/k4actstracking/package.py
@@ -1,9 +1,9 @@
 from spack.package import *
 
 try:
-    import spack.llnl.util.tty as tty
+    import spack.util.tty as tty
 except ImportError:
-    import llnl.util.tty as tty
+    import spack.llnl.util.tty as tty
 
 try:
     from spack.pkg.k4.k4actstracking import K4actstracking as BuiltinK4actstracking

--- a/spack_repo/eic/packages/k4fwcore/package.py
+++ b/spack_repo/eic/packages/k4fwcore/package.py
@@ -1,9 +1,9 @@
 from spack.package import *
 
 try:
-    import spack.llnl.util.tty as tty
+    import spack.util.tty as tty
 except ImportError:
-    import llnl.util.tty as tty
+    import spack.llnl.util.tty as tty
 
 try:
     from spack.pkg.k4.k4fwcore import K4fwcore as BuiltinK4fwcore


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes errors like https://github.com/eic/eic-spack/actions/runs/28883491804/job/85677616464?pr=974 due to the ongoing transition away from spack.llnl upstream. We use a moving target spack:develop, mostly because it's better to be future proof than stuck in the past.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

High priority since holding up other PRs.