### PR TITLE
timeframebuilder: new package

### DIFF
--- a/spack_repo/eic/packages/timeframebuilder/package.py
+++ b/spack_repo/eic/packages/timeframebuilder/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Timeframebuilder(CMakePackage):
+    """A Timeframe Builder to combine signal and background events."""
+
+    homepage = "https://github.com/eic/TimeframeBuilder"
+    url = "https://github.com/eic/TimeframeBuilder/archive/refs/tags/v0.9.0.tar.gz"
+    list_url = "https://github.com/eic/TimeframeBuilder/tags"
+    git = "https://github.com/eic/TimeframeBuilder.git"
+
+    maintainers("simonge")
+
+    tags = ["eic"]
+
+    version("main", branch="main")
+    version("0.9.0", sha256="9726690f74b32af37e598fbc23701f2bc14c30f4b877544ffc4c08648588ca52")
+
+    depends_on("cxx", type="build")
+
+    depends_on("hepmc3")
+    depends_on("edm4hep")
+    depends_on("podio")
+    depends_on("root")
+    depends_on("yaml-cpp")
+            
+
+    def cmake_args(self):
+        args = [
+            self.define("TIMEFRAME_BUILDER_VERSION_FULL", self.version),
+            self.define("CMAKE_CXX_STANDARD", self.spec["root"].variants["cxxstd"].value),
+        ]
+        return args

--- a/spack_repo/eic/packages/timeframebuilder/package.py
+++ b/spack_repo/eic/packages/timeframebuilder/package.py
@@ -31,7 +31,6 @@ class Timeframebuilder(CMakePackage):
     depends_on("podio")
     depends_on("root")
     depends_on("yaml-cpp")
-            
 
     def cmake_args(self):
         args = [

--- a/spack_repo/eic/packages/timeframebuilder/package.py
+++ b/spack_repo/eic/packages/timeframebuilder/package.py
@@ -26,7 +26,7 @@ class Timeframebuilder(CMakePackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("hepmc3")
+    depends_on("hepmc3 +rootio")
     depends_on("edm4hep")
     depends_on("podio")
     depends_on("root")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Adds the TimeframeBuilder package. Used for merging HepMC3 or EDM4hep events to generate realistic timeframes by distributing events based on bunch crossing times and locations

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
