### PR TITLE
eicsimubeameffects: drop old versions, add 1.0 and 1.1

### DIFF
--- a/spack_repo/eic/packages/eicsimubeameffects/package.py
+++ b/spack_repo/eic/packages/eicsimubeameffects/package.py
@@ -23,6 +23,7 @@ class Eicsimubeameffects(CMakePackage):
     version("1.1", sha256="b71279829d88f690118725bbfcf378fccb6d0f79ba8a595932617a3c1e8b79aa")
     version("1.0", sha256="f981f84be6fe9bf6ae7420fecc16e5c7ac6905ad9f18c789f5c0ef1beec0cb46")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@3.20:", type="build")
 

--- a/spack_repo/eic/packages/eicsimubeameffects/package.py
+++ b/spack_repo/eic/packages/eicsimubeameffects/package.py
@@ -21,7 +21,7 @@ class Eicsimubeameffects(CMakePackage):
 
     version("master", branch="master")
     version("1.1", sha256="b71279829d88f690118725bbfcf378fccb6d0f79ba8a595932617a3c1e8b79aa")
-    version("1.0", sha256="0000000000000000000000000000000000000000000000000000000000000000")
+    version("1.0", sha256="f981f84be6fe9bf6ae7420fecc16e5c7ac6905ad9f18c789f5c0ef1beec0cb46")
 
     depends_on("cxx", type="build")
     depends_on("cmake@3.20:", type="build")

--- a/spack_repo/eic/packages/eicsimubeameffects/package.py
+++ b/spack_repo/eic/packages/eicsimubeameffects/package.py
@@ -20,6 +20,7 @@ class Eicsimubeameffects(CMakePackage):
     tags = ["eic"]
 
     version("master", branch="master")
+    version("1.1", sha256="b71279829d88f690118725bbfcf378fccb6d0f79ba8a595932617a3c1e8b79aa")
     version("1.0", sha256="0000000000000000000000000000000000000000000000000000000000000000")
 
     depends_on("cxx", type="build")

--- a/spack_repo/eic/packages/eicsimubeameffects/package.py
+++ b/spack_repo/eic/packages/eicsimubeameffects/package.py
@@ -11,9 +11,7 @@ class Eicsimubeameffects(CMakePackage):
     """EIC beam effects simulation studies and utilities."""
 
     homepage = "https://github.com/eic/eicSimuBeamEffects"
-    url = (
-        "https://github.com/eic/eicSimuBeamEffects/archive/refs/tags/production_2021-09-27.tar.gz"
-    )
+    url = "https://github.com/eic/eicSimuBeamEffects/archive/refs/tags/v1.0.tar.gz"
     list_url = "https://github.com/eic/eicSimuBeamEffects/tags"
     git = "https://github.com/eic/eicSimuBeamEffects.git"
 
@@ -22,17 +20,7 @@ class Eicsimubeameffects(CMakePackage):
     tags = ["eic"]
 
     version("master", branch="master")
-    version(
-        "2021-09-27", sha256="445a637ecc5ad35d4d0b60a7049abf8e66c3c2d6f6778accd5094ed1e092f9be"
-    )
-    version(
-        "2021-08-06", sha256="cadcfa748dea80ec12c5388aa98e74780aaab79051743f2302d62d681eee859a"
-    )
-    version(
-        "production_2021-09-27",
-        sha256="445a637ecc5ad35d4d0b60a7049abf8e66c3c2d6f6778accd5094ed1e092f9be",
-        deprecated=True,
-    )
+    version("1.0", sha256="0000000000000000000000000000000000000000000000000000000000000000")
 
     depends_on("cxx", type="build")
     depends_on("cmake@3.20:", type="build")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Old url/version is recognized as `https://github.com/eic/eicSimuBeamEffects/archive/refs/tags/production_<version>.tar.gz` pattern.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
