### PR TITLE
simphony: make the DD4hep plugins discoverable at runtime

### DIFF
--- a/spack_repo/eic/packages/simphony/package.py
+++ b/spack_repo/eic/packages/simphony/package.py
@@ -59,3 +59,7 @@ class Simphony(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", self.spec.satisfies("@0.6:") and self.run_tests)]
         return args
+
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("@0.6.0:"):
+            env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)


### PR DESCRIPTION
For `simphony@0.6.0:` the package depends on dd4hep, and the build auto detects it and installs the DDG4 integration plugins (`lib/libddsimphony.so` + `libddsimphony.components`). But the installed plugins are not discoverable at runtime: dd4hep's plugin registry locates factories by scanning the directories on `LD_LIBRARY_PATH` for `*.components` files, and nothing puts simphony's lib there. So a DDG4 steering file using the simphony actions (`OpticsRun`, `OpticsEvent`, `OpticsSteppingAction`) fails with an unknown plugin error until the user exports the path.

This adds a `setup_run_environment` that prepends `prefix.lib` to `LD_LIBRARY_PATH`, following the same pattern the dd4hep package itself uses for plugin lookup. 