### PR TITLE
feat: add epic 26.08.0 and eicrecon 1.40.0

### DIFF
--- a/spack_repo/eic/packages/eicrecon/package.py
+++ b/spack_repo/eic/packages/eicrecon/package.py
@@ -75,7 +75,7 @@ class Eicrecon(CMakePackage):
     depends_on("jana2 +podio +root +zmq")
     depends_on("dd4hep +ddrec +edm4hep")
     depends_on("edm4eic")
-    depends_on("edm4eic@8.7.0", when="@1.40:")
+    depends_on("edm4eic@8.7.0:", when="@1.40:")
     depends_on("edm4hep")
     depends_on("podio")
 

--- a/spack_repo/eic/packages/eicrecon/package.py
+++ b/spack_repo/eic/packages/eicrecon/package.py
@@ -21,6 +21,7 @@ class Eicrecon(CMakePackage):
     maintainers = ["wdconinc"]
 
     version("main", branch="main")
+    version("1.40.0", sha256="d5ac2bbe17093941f69e819aaa70987166a3ad838561319366da05a33cccee78")
     version("1.39.2", sha256="9068425ba5f1a778efab2930fad8b37c81171e34d764b7f93e70fe9bd56cb4b6")
     version("1.39.1", sha256="d2f8b8af03d669659b698a4ef8e3c793b39d99196d76c1c81b00e326212c125d")
     version("1.39.0", sha256="30a8723633544c11d57d9546a0af7ebb76ddc425910dbdef74f83f5b6499129f")

--- a/spack_repo/eic/packages/eicrecon/package.py
+++ b/spack_repo/eic/packages/eicrecon/package.py
@@ -75,6 +75,7 @@ class Eicrecon(CMakePackage):
     depends_on("jana2 +podio +root +zmq")
     depends_on("dd4hep +ddrec +edm4hep")
     depends_on("edm4eic")
+    depends_on("edm4eic@8.7.0", when="@1.40:")
     depends_on("edm4hep")
     depends_on("podio")
 

--- a/spack_repo/eic/packages/epic/package.py
+++ b/spack_repo/eic/packages/epic/package.py
@@ -18,6 +18,7 @@ class Epic(CMakePackage):
     tags = ["eic"]
 
     version("main", branch="main")
+    version("26.08.0", sha256="2fc6d39db5a84be0ddbc6ad7fdeaac603d080924e4a3035a0500251fc93b6f9c")
     version("26.07.2", sha256="42876a5330754d0aedcd4f511be43cf454f9f73304d0c0a3f404080e91c30feb")
     version("26.07.1", sha256="ec1ddb53d890f1ae0cb11caf9e3f665a7c97c8654c45cbd255ccc03a4328553d")
     version("26.07.0", sha256="2aca0731292f7715661ea5ce7d62d7b0f6ba444e66f2b74a7e28a619b87a92f6")


### PR DESCRIPTION
Adds new versions:
- epic 26.08.0 (https://github.com/eic/epic/releases/tag/26.08.0)
- eicrecon 1.40.0 (https://github.com/eic/EICrecon/releases/tag/v1.40.0)